### PR TITLE
Lint in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@
   </p>
 </p>
 
+- [About](#about)
+- [Usage](#usage)
+  * [Run in parallel](#run-in-parallel)
+- [Installation](#installation)
+  * [As a project dependency:](#as-a-project-dependency)
+  * [OS X](#os-x)
+  * [Docker](#docker)
+  * [From sources](#from-sources)
+- [Configuration](#configuration)
+  * [Only/Except](#onlyexcept)
+  * [Explanation](#explanation)
+  * [Inline disabling](#inline-disabling)
+- [Editor integration](#editor-integration)
+- [Credits & inspirations](#credits--inspirations)
+- [Contributors](#contributors)
+
 ## About
 
 Ameba is a static code analysis tool for the Crystal language.
@@ -47,6 +63,26 @@ Finished in 542.64 milliseconds
 
 129 inspected, 2 failures.
 
+```
+
+### Run in parallel
+
+Starting from 0.31.0 Crystal [supports parallelism](https://crystal-lang.org/2019/09/06/parallelism-in-crystal.html).
+It allows to run linting in parallel too.
+In order to take advantage of this feature you need to build ameba with preview_mt support:
+
+```
+$ crystal build src/cli.cr -Dpreview_mt -o bin/ameba
+$ make install
+```
+
+Some quick benchmark results measured while running Ameba on Crystal repo:
+
+```
+$ CRYSTAL_WORKERS=1 ameba #=> 29.11 seconds
+$ CRYSTAL_WORKERS=2 ameba #=> 19.49 seconds
+$ CRYSTAL_WORKERS=4 ameba #=> 13.48 seconds
+$ CRYSTAL_WORKERS=8 ameba #=> 10.14 seconds
 ```
 
 ## Installation

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -53,6 +53,19 @@ module Ameba
         Runner.new(all_rules, [source], formatter, default_severity).run.success?.should be_true
       end
 
+      context "exception in rule" do
+        it "raises an exception raised in fiber while running a rule" do
+          rule = RaiseRule.new
+          rule.should_raise = true
+          rules = [rule] of Rule::Base
+          source = Source.new "", "source.cr"
+
+          expect_raises(Exception, "something went wrong") do
+            Runner.new(rules, [source], formatter, default_severity).run
+          end
+        end
+      end
+
       context "invalid syntax" do
         it "reports a syntax error" do
           rules = [Rule::Lint::Syntax.new] of Rule::Base

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -81,6 +81,15 @@ module Ameba
     end
   end
 
+  # A rule that always raises an error
+  struct RaiseRule < Rule::Base
+    property should_raise = false
+
+    def test(source)
+      should_raise && raise "something went wrong"
+    end
+  end
+
   class DummyFormatter < Formatter::BaseFormatter
     property started_sources : Array(Source)?
     property finished_sources : Array(Source)?

--- a/src/ameba/formatter/flycheck_formatter.cr
+++ b/src/ameba/formatter/flycheck_formatter.cr
@@ -1,12 +1,16 @@
 module Ameba::Formatter
   class FlycheckFormatter < BaseFormatter
+    @mutex = Mutex.new
+
     def source_finished(source : Source)
       source.issues.each do |e|
         next if e.disabled?
         if loc = e.location
-          output.printf "%s:%d:%d: %s: [%s] %s\n",
-            source.path, loc.line_number, loc.column_number, e.rule.severity.symbol,
-            e.rule.name, e.message.gsub("\n", " ")
+          @mutex.synchronize do
+            output.printf "%s:%d:%d: %s: [%s] %s\n",
+              source.path, loc.line_number, loc.column_number, e.rule.severity.symbol,
+              e.rule.name, e.message.gsub("\n", " ")
+          end
         end
       end
     end


### PR DESCRIPTION
Here we spawn each source in parallel. 

```
crystal build src/cli.cr -Dpreview_mt -o bin/ameba
sudo make install
```

Some results while running Ameba on Crystal repo (1442 files):

```
CRYSTAL_WORKERS=1 ameba #=> 29.11 seconds
CRYSTAL_WORKERS=2 ameba #=> 19.49 seconds
CRYSTAL_WORKERS=4 ameba #=> 13.48 seconds
CRYSTAL_WORKERS=8 ameba #=> 10.14 seconds
```

Todo:

- [x] re-raise exceptions raised in fibers
- [x] synchorize `printf` output for `FlycheckFormatter`