### PR TITLE
Ability to configure globs and globally excluded paths 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
   * [Docker](#docker)
   * [From sources](#from-sources)
 - [Configuration](#configuration)
-  * [Only/Except](#onlyexcept)
-  * [Explanation](#explanation)
+  * [Sources](#sources)
+  * [Rules](#rules)
+  * [Explain issues](#explain-issues)
   * [Inline disabling](#inline-disabling)
 - [Editors & integrations](#editors--integrations)
 - [Credits & inspirations](#credits--inspirations)
@@ -150,7 +151,37 @@ It allows to configure rule properties, disable specific rules and exclude sourc
 
 Generate new file by running `ameba --gen-config`.
 
-### Only/Except
+### Sources
+
+**List of sources to run Ameba on can be configured globally via:**
+
+- `Globs` section - an array of wildcards (or paths) to include to the
+  inspection. Defaults to `%w(**/*.cr !lib)`, meaning it includes all project
+  files with `*.cr` extension except those which exist in `lib` folder.
+- `Excluded` section - an array of wildcards (or paths) to exclude from the
+  source list defined by `Globs`. Defaults to an empty array.
+
+In this example we define default globs and exclude `src/compiler` folder:
+
+``` yaml
+Globs:
+  - **/*.cr
+  - !lib
+  
+Excluded:
+  - src/compiler
+```
+
+**Specific sources can be excluded at rule level**:
+
+``` yaml
+Style/RedundantBegin:
+  Excluded:
+  - src/server/processor.cr
+  - src/server/api.cr
+```
+
+### Rules
 
 One or more rules, or a one or more group of rules can be included or excluded
 via command line arguments:
@@ -162,7 +193,14 @@ $ ameba --except Lint/Syntax # runs all rules except Lint/Syntax
 $ ameba --except Style,Lint  # runs all rules except rules in Style and Lint groups
 ```
 
-### Explanation
+Or through the configuration file:
+
+``` yaml
+Style/RedundantBegin:
+  Enabled: false
+```
+
+### Explain issues
 
 Ameba allows you to dig deeper into an issue, by showing you details about the issue
 and the reasoning by it being reported.

--- a/spec/ameba/config_spec.cr
+++ b/spec/ameba/config_spec.cr
@@ -8,6 +8,42 @@ module Ameba
       Config::AVAILABLE_FORMATTERS.should_not be_nil
     end
 
+    describe ".new" do
+      it "loads default globs when config is empty" do
+        yml = YAML.parse "{}"
+        config = Config.new(yml)
+        config.globs.should eq Config::DEFAULT_GLOBS
+      end
+
+      it "initializes globs as string" do
+        yml = YAML.parse <<-CONFIG
+          ---
+          Globs: src/*.cr
+          CONFIG
+        config = Config.new(yml)
+        config.globs.should eq %w(src/*.cr)
+      end
+
+      it "initializes globs as array" do
+        yml = YAML.parse <<-CONFIG
+          ---
+          Globs:
+           - "src/*.cr"
+           - "!spec"
+          CONFIG
+        config = Config.new(yml)
+        config.globs.should eq %w(src/*.cr !spec)
+      end
+
+      it "raises if Globs has a wrong type" do
+        yml = YAML.parse <<-CONFIG
+          ---
+          Globs: 100
+          CONFIG
+        expect_raises(Exception, "incorrect 'Globs' section in a config file") { Config.new(yml) }
+      end
+    end
+
     describe ".load" do
       it "loads custom config" do
         config = Config.load config_sample
@@ -28,7 +64,7 @@ module Ameba
       config = Config.load config_sample
 
       it "holds source globs" do
-        config.globs.should contain "spec/ameba/config_spec.cr"
+        config.globs.should eq Config::DEFAULT_GLOBS
       end
 
       it "allows to set globs" do

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -8,7 +8,7 @@ module Ameba::Cli
   def run(args = ARGV)
     opts = parse_args args
     config = Config.load opts.config, opts.colors?
-    config.globs = opts.globs
+    config.globs = opts.globs.not_nil! if opts.globs
     config.severity = opts.fail_level.not_nil! if opts.fail_level
 
     configure_formatter(config, opts)

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -177,7 +177,7 @@ class Ameba::Config
 
   private def load_array_section(config, section_name, default = [] of String)
     case value = config[section_name]?
-    when .nil? then default
+    when .nil?  then default
     when .as_s? then [value.to_s]
     when .as_a? then value.as_a.map(&.as_s)
     else


### PR DESCRIPTION
- [x] add the ability to configure globs:
  


Examples:

`!` means exclude (as it works for `Excluded` section at rule level)

```yml
Globs: **/*.cr

Globs:
  - "**/*.cr"
  - "!spec/server/*.cr"

# defaults to

Globs:
  - "**/*.cr"
  - "!lib"
```

- [x] add the ability to exclude globally (meaning exclude from globs):

```yml
Excluded:
  - spec
  - src/server/*.cr
```

- [x] document sections
---

should close #124