### PR TITLE
New rule: Lint/BadDirective

### DIFF
--- a/spec/ameba/rule/lint/bad_directive_spec.cr
+++ b/spec/ameba/rule/lint/bad_directive_spec.cr
@@ -1,0 +1,66 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  describe BadDirective do
+    subject = BadDirective.new
+
+    it "does not report if rule is correct" do
+      s = Source.new %(
+        # ameba:disable Lint/BadDirective
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "reports if there is incorrect action" do
+      s = Source.new %(
+        # ameba:foo Lint/BadDirective
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+      s.issues.size.should eq 1
+
+      issue = s.issues.first
+      issue.message.should eq(
+        "Bad action in comment directive: 'foo'. Possible values: disable,enable"
+      )
+      issue.location.to_s.should eq "source.cr:1:1"
+      issue.end_location.to_s.should eq ""
+    end
+
+    it "reports if there are incorrect rule names" do
+      s = Source.new %(
+        # ameba:enable BadRule1,BadRule2
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+      s.issues.size.should eq 1
+
+      issue = s.issues.first
+      issue.message.should eq(
+        "Such rules do not exist: 'BadRule1,BadRule2'"
+      )
+      issue.location.to_s.should eq "source.cr:1:1"
+      issue.end_location.to_s.should eq ""
+    end
+
+    it "does not report if there no action and rules at all" do
+      s = Source.new %(
+        # ameba:
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "does not report if there are no rules" do
+      s = Source.new %(
+        # ameba:enable
+        # ameba:disable
+      )
+      subject.catch(s).should be_valid
+    end
+
+    it "does not report if there are group names in the directive" do
+      s = Source.new %(
+        # ameba:disable Style Performance
+      )
+      subject.catch(s).should be_valid
+    end
+  end
+end

--- a/spec/ameba/rule/lint/bad_directive_spec.cr
+++ b/spec/ameba/rule/lint/bad_directive_spec.cr
@@ -20,7 +20,7 @@ module Ameba::Rule::Lint
 
       issue = s.issues.first
       issue.message.should eq(
-        "Bad action in comment directive: 'foo'. Possible values: disable,enable"
+        "Bad action in comment directive: 'foo'. Possible values: disable, enable"
       )
       issue.location.to_s.should eq "source.cr:1:1"
       issue.end_location.to_s.should eq ""
@@ -35,7 +35,7 @@ module Ameba::Rule::Lint
 
       issue = s.issues.first
       issue.message.should eq(
-        "Such rules do not exist: 'BadRule1,BadRule2'"
+        "Such rules do not exist: BadRule1, BadRule2"
       )
       issue.location.to_s.should eq "source.cr:1:1"
       issue.end_location.to_s.should eq ""

--- a/src/ameba/inline_comments.cr
+++ b/src/ameba/inline_comments.cr
@@ -1,7 +1,7 @@
 module Ameba
   # A module that utilizes inline comments parsing and processing logic.
   module InlineComments
-    COMMENT_DIRECTIVE_REGEX = Regex.new "# ameba : (\\w+) ([\\w/, ]+)".gsub(" ", "\\s*")
+    COMMENT_DIRECTIVE_REGEX = Regex.new "# ameba : (\\w+) ([\\w/, ]*)".gsub(" ", "\\s*")
 
     # Available actions in the inline comments
     enum Action
@@ -19,20 +19,20 @@ module Ameba
     # For example, here are two examples of disabled location:
     #
     # ```
-    # # ameba:disable LargeNumbers
+    # # ameba:disable Style/LargeNumbers
     # Time.epoch(1483859302)
     #
-    # Time.epoch(1483859302) # ameba:disable LargeNumbers
+    # Time.epoch(1483859302) # ameba:disable Style/LargeNumbers
     # ```
     #
     # But here are examples which are not considered as disabled location:
     #
     # ```
-    # # ameba:disable LargeNumbers
+    # # ameba:disable Style/LargeNumbers
     # #
     # Time.epoch(1483859302)
     #
-    # if use_epoch? # ameba:disable LargeNumbers
+    # if use_epoch? # ameba:disable Style/LargeNumbers
     #   Time.epoch(1483859302)
     # end
     # ```

--- a/src/ameba/rule/lint/bad_directive.cr
+++ b/src/ameba/rule/lint/bad_directive.cr
@@ -23,7 +23,7 @@ module Ameba::Rule::Lint
       description "Reports bad comment directives"
     end
 
-    AVAILABLE_ACTIONS = InlineComments::Action.names.join(',', &.downcase)
+    AVAILABLE_ACTIONS = InlineComments::Action.names.map(&.downcase)
     ALL_RULE_NAMES    = Rule.rules.map(&.rule_name)
     ALL_GROUP_NAMES   = Rule.rules.map(&.group_name).uniq!
 
@@ -42,13 +42,13 @@ module Ameba::Rule::Lint
 
       issue_for token,
         "Bad action in comment directive: '%s'. Possible values: %s" % {
-          action, AVAILABLE_ACTIONS,
+          action, AVAILABLE_ACTIONS.join(", "),
         }
     end
 
     private def check_rules(source, token, rules)
-      return if (bad_names = rules - ALL_RULE_NAMES - ALL_GROUP_NAMES).empty?
-      issue_for token, "Such rules do not exist: '%s'" % bad_names.join(',')
+      bad_names = rules - ALL_RULE_NAMES - ALL_GROUP_NAMES
+      issue_for token, "Such rules do not exist: %s" % bad_names.join(", ") if bad_names.any?
     end
   end
 end

--- a/src/ameba/rule/lint/bad_directive.cr
+++ b/src/ameba/rule/lint/bad_directive.cr
@@ -1,0 +1,54 @@
+module Ameba::Rule::Lint
+  # A rule that reports incorrect comment directives for Ameba.
+  #
+  # For example, the user can mistakenly add a directive
+  # to disable a rule that even doesn't exist:
+  #
+  # ```
+  # # ameba:disable BadRuleName
+  # def foo
+  #   :bar
+  # end
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/BadDirective:
+  #   Enabled: true
+  # ```
+  #
+  struct BadDirective < Base
+    properties do
+      description "Reports bad comment directives"
+    end
+
+    AVAILABLE_ACTIONS = InlineComments::Action.names.join(',', &.downcase)
+    ALL_RULE_NAMES    = Rule.rules.map(&.rule_name)
+    ALL_GROUP_NAMES   = Rule.rules.map(&.group_name).uniq!
+
+    def test(source)
+      Tokenizer.new(source).run do |token|
+        next unless token.type == :COMMENT
+        next unless directive = source.parse_inline_directive(token.value.to_s)
+
+        check_action source, token, directive[:action]
+        check_rules source, token, directive[:rules]
+      end
+    end
+
+    private def check_action(source, token, action)
+      return if InlineComments::Action.parse?(action)
+
+      issue_for token,
+        "Bad action in comment directive: '%s'. Possible values: %s" % {
+          action, AVAILABLE_ACTIONS,
+        }
+    end
+
+    private def check_rules(source, token, rules)
+      return if (bad_names = rules - ALL_RULE_NAMES - ALL_GROUP_NAMES).empty?
+      issue_for token, "Such rules do not exist: '%s'" % bad_names.join(',')
+    end
+  end
+end

--- a/src/ameba/rule/lint/unneeded_disable_directive.cr
+++ b/src/ameba/rule/lint/unneeded_disable_directive.cr
@@ -3,7 +3,7 @@ module Ameba::Rule::Lint
   # For example, this is considered invalid:
   #
   # ```
-  # # ameba:disable PredicateName
+  # # ameba:disable Style/PredicateName
   # def comment?
   #   do_something
   # end
@@ -16,6 +16,13 @@ module Ameba::Rule::Lint
   # def comment?
   #   do_something
   # end
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/UnneededDisableDirective
+  #   Enabled: true
   # ```
   #
   struct UnneededDisableDirective < Base


### PR DESCRIPTION
A rule that reports incorrect comment directives for Ameba.

For example, the user can mistakenly add a directive to disable a rule that even doesn't exist:

```crystal
# ameba:disable BadRuleName
def foo
  :bar
end
```

YAML configuration example:

```yml
Lint/BadDirective:
  Enabled: true
```

