### PR TITLE
Move to YAML::Serializable

### DIFF
--- a/spec/ameba/base_spec.cr
+++ b/spec/ameba/base_spec.cr
@@ -1,18 +1,12 @@
 require "../spec_helper"
 
 module Ameba::Rule
-  struct NoProperties < Rule::Base
-    def test(source)
-    end
-  end
-
   describe Base do
     context ".rules" do
       it "returns a list of all rules" do
         rules = Rule.rules
         rules.should_not be_nil
         rules.should contain DummyRule
-        rules.should contain NoProperties
       end
     end
 
@@ -29,12 +23,6 @@ module Ameba::Rule
 
       it "has excluded property" do
         subject.excluded.should be_nil
-      end
-    end
-
-    describe "when a rule does not have defined properties" do
-      it "is enabled by default" do
-        NoProperties.new.enabled.should be_true
       end
     end
 
@@ -80,7 +68,7 @@ module Ameba::Rule
       end
 
       it "returns false if rule has a different name" do
-        DummyRule.new.should_not eq(NoProperties.new)
+        DummyRule.new.should_not eq(ScopeRule.new)
       end
     end
   end

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -93,11 +93,11 @@ module Ameba
         # Run `ameba --only Ameba/DummyRule` for details
         Ameba/DummyRule:
           Description: Dummy rule that does nothing.
-          Enabled: true
-          Severity: Convention
           Excluded:
           - source1.cr
           - source2.cr
+          Enabled: true
+          Severity: Convention
         CONTENT
       end
 

--- a/spec/ameba/severity_spec.cr
+++ b/spec/ameba/severity_spec.cr
@@ -44,9 +44,10 @@ module Ameba
   end
 
   struct SeverityConvertable
-    YAML.mapping(
-      severity: {type: Severity, converter: SeverityYamlConverter}
-    )
+    include YAML::Serializable
+
+    @[YAML::Field(converter: Ameba::SeverityYamlConverter)]
+    property severity : Severity
   end
 
   describe SeverityYamlConverter do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -37,10 +37,7 @@ module Ameba
 
   struct NamedRule < Rule::Base
     properties do
-      description : String = "A rule with a custom name."
-    end
-
-    def test(source)
+      description "A rule with a custom name."
     end
 
     def self.name
@@ -50,7 +47,7 @@ module Ameba
 
   struct ErrorRule < Rule::Base
     properties do
-      description : String = "Always adds an error at 1:1"
+      description "Always adds an error at 1:1"
     end
 
     def test(source)
@@ -59,9 +56,11 @@ module Ameba
   end
 
   struct ScopeRule < Rule::Base
+    @[YAML::Field(ignore: true)]
     getter scopes = [] of AST::Scope
 
-    def test(source)
+    properties do
+      description "Internal rule to test scopes"
     end
 
     def test(source, node : Crystal::ASTNode, scope : AST::Scope)
@@ -70,9 +69,11 @@ module Ameba
   end
 
   struct FlowExpressionRule < Rule::Base
+    @[YAML::Field(ignore: true)]
     getter expressions = [] of AST::FlowExpression
 
-    def test(source)
+    properties do
+      description "Internal rule to test flow expressions"
     end
 
     def test(source, node, flow_expression : AST::FlowExpression)
@@ -81,9 +82,11 @@ module Ameba
   end
 
   struct RedundantControlExpressionRule < Rule::Base
+    @[YAML::Field(ignore: true)]
     getter nodes = [] of Crystal::ASTNode
 
-    def test(source)
+    properties do
+      description "Internal rule to test redundant control expressions"
     end
 
     def test(source, node, visitor : AST::RedundantControlExpressionVisitor)
@@ -94,6 +97,10 @@ module Ameba
   # A rule that always raises an error
   struct RaiseRule < Rule::Base
     property should_raise = false
+
+    properties do
+      description "Internal rule that always raises"
+    end
 
     def test(source)
       should_raise && raise "something went wrong"

--- a/src/ameba/rule/lint/syntax.cr
+++ b/src/ameba/rule/lint/syntax.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Lint
   struct Syntax < Base
     properties do
       description "Reports invalid Crystal syntax"
-      severity Severity::Error
+      severity Ameba::Severity::Error
     end
 
     def test(source)


### PR DESCRIPTION
Moving from `YAML.mapping` (which is deprecated) to `YAML::Serializable`.

This also adds two requirements to the rules:

1. `properties` block becomes required now. But, I think this is fine since at least the rule description is required to be defined.

For example, this will not compile now:

```crystal
struct TestRule < Rule::Base
  def test
    # ....
  end
end
```

this is the way to define rules:

```crystal
struct TestRule < Rule::Base
  properties do
     description "My Test Rule"
  end

  def test
    # ....
  end
end
```

2. Rule properties, which does have to be serialized will have to be marked explicitly as ignored:

```crystal
struct TestRule < Rule::Base

  @[YAML::Field(ignore: true)]
  @foo : Bar

  def test
    # ....
  end
end
```


---

I tried to get rid of [custom macro](https://github.com/crystal-ameba/ameba/blob/c3260c1740bd2e2750bc013fd5beba965c683fc3/src/ameba/config.cr#L190-L264) in a rule config, however, it still seems impossible to do without breaking the existed yaml format for defining a configuration file. Maybe in the future we will move to [yaml_discriminator](https://crystal-lang.org/api/0.35.0/YAML/Serializable.html#use_yaml_discriminator(field,mapping)-macro) which will definitely help to simplify our implementation (but break the config)