### PR TITLE
Add support for showing code context lines

### DIFF
--- a/src/ameba/formatter/explain_formatter.cr
+++ b/src/ameba/formatter/explain_formatter.cr
@@ -49,7 +49,7 @@ module Ameba::Formatter
         @location.to_s.colorize(:cyan).to_s,
       ]
 
-      if affected_code = affected_code(source, @location)
+      if affected_code = affected_code(source, @location, context_lines: 3)
         output_title "AFFECTED CODE"
         output_paragraph affected_code
       end

--- a/src/ameba/formatter/util.cr
+++ b/src/ameba/formatter/util.cr
@@ -1,6 +1,6 @@
 module Ameba::Formatter
   module Util
-    def affected_code(source, location, context_lines = 3, max_length = 100, placeholder = " ...", prompt = "> ")
+    def affected_code(source, location, context_lines = 0, max_length = 100, placeholder = " ...", prompt = "> ")
       lines = source.lines
       lineno, column =
         location.line_number, location.column_number

--- a/src/ameba/formatter/util.cr
+++ b/src/ameba/formatter/util.cr
@@ -1,5 +1,9 @@
 module Ameba::Formatter
   module Util
+    def deansify(message : String?) : String?
+      message.try &.gsub(/\x1b[^m]*m/, "").presence
+    end
+
     def affected_code(source, location, context_lines = 0, max_length = 100, placeholder = " ...", prompt = "> ")
       lines = source.lines
       lineno, column =


### PR DESCRIPTION
PoC of affected code context lines feature. Resolves #93

I've pushed it for others to judge, but I believe that showing context lines adds no value practical value and amounts to visual noise instead.

At the moment looks like this:

![image](https://user-images.githubusercontent.com/988/104129844-5acfae00-536e-11eb-8943-4e3333234445.png)
