### PR TITLE
fix Crystal nightly

### DIFF
--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -5,7 +5,7 @@ module Ameba
     getter issues = [] of Issue
 
     # Adds a new issue to the list of issues.
-    def add_issue(rule, location, end_location, message, status = nil)
+    def add_issue(rule, location : Crystal::Location?, end_location : Crystal::Location?, message, status = nil)
       status ||= :disabled if location_disabled?(location, rule)
       issues << Issue.new rule, location, end_location, message, status
     end


### PR DESCRIPTION
```
Building: ameba
Error target ameba failed to compile:
Showing last frame. Use --error-trace for full trace.

In src/ameba/inline_comments.cr:42:56

 42 | return false unless line_number = location.try &.line_number.try &.- 1
                                                       ^----------
Error: undefined method 'line_number' for Tuple(Int32, Int32)

make: *** [Makefile:8: bin/ameba] Error 1
Error: Process completed with exit code 1.
```