### PR TITLE
New Rule: Lint/DuplicatedRequire

### DIFF
--- a/spec/ameba/ast/visitors/top_level_nodes_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/top_level_nodes_visitor_spec.cr
@@ -1,0 +1,17 @@
+require "../../../spec_helper"
+
+module Ameba::AST
+  describe TopLevelNodesVisitor do
+    describe "#require_nodes" do
+      it "returns require node" do
+        source = Source.new %(
+          require "foo"
+          def bar; end
+        )
+        visitor = TopLevelNodesVisitor.new(source.ast)
+        visitor.require_nodes.size.should eq 1
+        visitor.require_nodes.first.to_s.should eq %q(require "foo")
+      end
+    end
+  end
+end

--- a/spec/ameba/rule/lint/duplicated_require_spec.cr
+++ b/spec/ameba/rule/lint/duplicated_require_spec.cr
@@ -1,0 +1,48 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  subject = DuplicatedRequire.new
+
+  describe DuplicatedRequire do
+    it "passes if there are no duplicated requires" do
+      source = Source.new %(
+        require "math"
+        require "big"
+        require "big/big_decimal"
+      )
+      subject.catch(source).should be_valid
+    end
+
+    it "reports if there are a duplicated requires" do
+      source = Source.new %(
+        require "big"
+        require "math"
+        require "big"
+      )
+      subject.catch(source).should_not be_valid
+    end
+
+    it "reports rule, pos and message" do
+      source = Source.new %(
+        require "./thing"
+        require "./thing"
+        require "./another_thing"
+        require "./another_thing"
+      ), "source.cr"
+
+      subject.catch(source).should_not be_valid
+
+      issue = source.issues.first
+      issue.rule.should_not be_nil
+      issue.location.to_s.should eq "source.cr:2:1"
+      issue.end_location.to_s.should eq ""
+      issue.message.should eq "Duplicated require of `./thing`"
+
+      issue = source.issues.last
+      issue.rule.should_not be_nil
+      issue.location.to_s.should eq "source.cr:4:1"
+      issue.end_location.to_s.should eq ""
+      issue.message.should eq "Duplicated require of `./another_thing`"
+    end
+  end
+end

--- a/src/ameba/ast/visitors/redundant_control_expression_visitor.cr
+++ b/src/ameba/ast/visitors/redundant_control_expression_visitor.cr
@@ -28,8 +28,6 @@ module Ameba::AST
       when Crystal::Case                then traverse_case node
       when Crystal::BinaryOp            then traverse_binary_op node
       when Crystal::ExceptionHandler    then traverse_exception_handler node
-      else
-        # ok
       end
     end
 

--- a/src/ameba/ast/visitors/top_level_nodes_visitor.cr
+++ b/src/ameba/ast/visitors/top_level_nodes_visitor.cr
@@ -1,0 +1,28 @@
+module Ameba::AST
+  # AST Visitor that visits certain nodes at a top level, which
+  # can characterize the source (i.e. require statements, modules etc.)
+  class TopLevelNodesVisitor < Crystal::Visitor
+    getter require_nodes = [] of Crystal::Require
+
+    # Creates a new instance of visitor
+    def initialize(@scope : Crystal::ASTNode)
+      @scope.accept(self)
+    end
+
+    # :nodoc:
+    def visit(node : Crystal::Require)
+      require_nodes << node
+    end
+
+    # If a top level node is Crystal::Expressions traverse the children.
+    def visit(node : Crystal::Expressions)
+      true
+    end
+
+    # A general visit method for rest of the nodes.
+    # Returns false meaning all child nodes will not be traversed.
+    def visit(node : Crystal::ASTNode)
+      false
+    end
+  end
+end

--- a/src/ameba/rule/lint/duplicated_require.cr
+++ b/src/ameba/rule/lint/duplicated_require.cr
@@ -1,0 +1,31 @@
+module Ameba::Rule::Lint
+  # A rule that reports duplicated require statements.
+  #
+  # ```
+  # require "./thing"
+  # require "./stuff"
+  # require "./thing" # duplicated require
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/DuplicatedRequire:
+  #   Enabled: true
+  # ```
+  struct DuplicatedRequire < Base
+    properties do
+      description "Reports duplicated require statements"
+    end
+
+    MSG = "Duplicated require of `%s`"
+
+    def test(source)
+      nodes = AST::TopLevelNodesVisitor.new(source.ast).require_nodes
+      nodes.each_with_object([] of String) do |node, processed_require_strings|
+        issue_for(node, MSG % node.string) if processed_require_strings.includes?(node.string)
+        processed_require_strings << node.string
+      end
+    end
+  end
+end


### PR DESCRIPTION
A rule that reports duplicated require statements.

```crystal
require "./thing"
require "./stuff"
require "./thing" # duplicated require
```

YAML configuration example:

```yml
Lint/DuplicatedRequire:
  Enabled: true
```

closes https://github.com/crystal-ameba/ameba/issues/176