### PR TITLE
Change Rule to a class

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,7 +3,7 @@ require "../src/ameba"
 
 module Ameba
   # Dummy Rule which does nothing.
-  struct DummyRule < Rule::Base
+  class DummyRule < Rule::Base
     properties do
       description : String = "Dummy rule that does nothing."
     end
@@ -35,7 +35,7 @@ module Ameba
     end
   end
 
-  struct NamedRule < Rule::Base
+  class NamedRule < Rule::Base
     properties do
       description "A rule with a custom name."
     end
@@ -45,7 +45,7 @@ module Ameba
     end
   end
 
-  struct ErrorRule < Rule::Base
+  class ErrorRule < Rule::Base
     properties do
       description "Always adds an error at 1:1"
     end
@@ -55,7 +55,7 @@ module Ameba
     end
   end
 
-  struct ScopeRule < Rule::Base
+  class ScopeRule < Rule::Base
     @[YAML::Field(ignore: true)]
     getter scopes = [] of AST::Scope
 
@@ -68,7 +68,7 @@ module Ameba
     end
   end
 
-  struct FlowExpressionRule < Rule::Base
+  class FlowExpressionRule < Rule::Base
     @[YAML::Field(ignore: true)]
     getter expressions = [] of AST::FlowExpression
 
@@ -81,7 +81,7 @@ module Ameba
     end
   end
 
-  struct RedundantControlExpressionRule < Rule::Base
+  class RedundantControlExpressionRule < Rule::Base
     @[YAML::Field(ignore: true)]
     getter nodes = [] of Crystal::ASTNode
 
@@ -95,7 +95,7 @@ module Ameba
   end
 
   # A rule that always raises an error
-  struct RaiseRule < Rule::Base
+  class RaiseRule < Rule::Base
     property should_raise = false
 
     properties do

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -121,16 +121,10 @@ module Ameba::Cli
   private def configure_rules(config, opts)
     case
     when only = opts.only
-      config.rules.map! do |rule|
-        rule.enabled = false
-        rule
-      end
+      config.rules.each(&.enabled = false)
       config.update_rules(only, enabled: true)
     when opts.all?
-      config.rules.map! do |rule|
-        rule.enabled = true
-        rule
-      end
+      config.rules.each(&.enabled = true)
     end
     config.update_rules(opts.except, enabled: false)
   end

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -135,13 +135,12 @@ class Ameba::Config
   # config.update_rule "MyRuleName", enabled: false
   # ```
   def update_rule(name, enabled = true, excluded = nil)
-    index = @rules.index { |rule| rule.name == name }
-    raise ArgumentError.new("Rule `#{name}` does not exist") unless index
+    rule = @rules.find(&.name.==(name))
+    raise ArgumentError.new("Rule `#{name}` does not exist") unless rule
 
-    rule = @rules[index]
-    rule.enabled = enabled
-    rule.excluded = excluded
-    @rules[index] = rule
+    rule
+      .tap(&.enabled = enabled)
+      .tap(&.excluded = excluded)
   end
 
   # Updates rules properties.
@@ -156,12 +155,15 @@ class Ameba::Config
   # ```
   # config.update_rules %w(Group1 Group2), enabled: true
   # ```
-  def update_rules(names, **args)
+  def update_rules(names, enabled = true, excluded = nil)
     names.try &.each do |name|
-      if group = @rule_groups[name]?
-        group.each { |rule| update_rule(rule.name, **args) }
+      if rules = @rule_groups[name]?
+        rules.each do |rule|
+          rule.enabled = enabled
+          rule.excluded = excluded
+        end
       else
-        update_rule name, **args
+        update_rule name, enabled, excluded
       end
     end
   end

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -10,7 +10,7 @@ module Ameba::Rule
   # inherits from this struct:
   #
   # ```
-  # struct MyRule < Ameba::Rule::Base
+  # class MyRule < Ameba::Rule::Base
   #   def test(source)
   #     if invalid?(source)
   #       issue_for line, column, "Something wrong."
@@ -26,7 +26,7 @@ module Ameba::Rule
   # Enforces rules to implement an abstract `#test` method which
   # is designed to test the source passed in. If source has issues
   # that are tested by this rule, it should add an issue.
-  abstract struct Base
+  abstract class Base
     include Config::RuleConfig
 
     # This method is designed to test the source passed in. If source has issues
@@ -56,7 +56,7 @@ module Ameba::Rule
     # Returns a name of this rule, which is basically a class name.
     #
     # ```
-    # struct MyRule < Ameba::Rule::Base
+    # class MyRule < Ameba::Rule::Base
     #   def test(source)
     #   end
     # end
@@ -70,7 +70,7 @@ module Ameba::Rule
     # Returns a group this rule belong to.
     #
     # ```
-    # struct MyGroup::MyRule < Ameba::Rule::Base
+    # class MyGroup::MyRule < Ameba::Rule::Base
     #   # ...
     # end
     #
@@ -140,7 +140,7 @@ module Ameba::Rule
     # module Ameba
     #   # This is a test rule.
     #   # Does nothing.
-    #   struct MyRule < Ameba::Rule::Base
+    #   class MyRule < Ameba::Rule::Base
     #     def test(source)
     #     end
     #   end

--- a/src/ameba/rule/layout/line_length.cr
+++ b/src/ameba/rule/layout/line_length.cr
@@ -8,7 +8,7 @@ module Ameba::Rule::Layout
   #   Enabled: true
   #   MaxLength: 100
   # ```
-  struct LineLength < Base
+  class LineLength < Base
     properties do
       enabled false
       description "Disallows lines longer than `MaxLength` number of symbols"

--- a/src/ameba/rule/layout/trailing_blank_lines.cr
+++ b/src/ameba/rule/layout/trailing_blank_lines.cr
@@ -7,7 +7,7 @@ module Ameba::Rule::Layout
   # Layout/TrailingBlankLines:
   #   Enabled: true
   # ```
-  struct TrailingBlankLines < Base
+  class TrailingBlankLines < Base
     properties do
       description "Disallows trailing blank lines"
     end

--- a/src/ameba/rule/layout/trailing_whitespace.cr
+++ b/src/ameba/rule/layout/trailing_whitespace.cr
@@ -7,7 +7,7 @@ module Ameba::Rule::Layout
   # Layout/TrailingWhitespace:
   #   Enabled: true
   # ```
-  struct TrailingWhitespace < Base
+  class TrailingWhitespace < Base
     properties do
       description "Disallows trailing whitespaces"
     end

--- a/src/ameba/rule/lint/bad_directive.cr
+++ b/src/ameba/rule/lint/bad_directive.cr
@@ -17,7 +17,7 @@ module Ameba::Rule::Lint
   # Lint/BadDirective:
   #   Enabled: true
   # ```
-  struct BadDirective < Base
+  class BadDirective < Base
     properties do
       description "Reports bad comment directives"
     end

--- a/src/ameba/rule/lint/comparison_to_boolean.cr
+++ b/src/ameba/rule/lint/comparison_to_boolean.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Lint
   # Lint/ComparisonToBoolean:
   #   Enabled: true
   # ```
-  struct ComparisonToBoolean < Base
+  class ComparisonToBoolean < Base
     properties do
       enabled false
       description "Disallows comparison to booleans"

--- a/src/ameba/rule/lint/debugger_statement.cr
+++ b/src/ameba/rule/lint/debugger_statement.cr
@@ -10,7 +10,7 @@ module Ameba::Rule::Lint
   # Lint/DebuggerStatement:
   #   Enabled: true
   # ```
-  struct DebuggerStatement < Base
+  class DebuggerStatement < Base
     properties do
       description "Disallows calls to debugger"
     end

--- a/src/ameba/rule/lint/duplicated_require.cr
+++ b/src/ameba/rule/lint/duplicated_require.cr
@@ -13,7 +13,7 @@ module Ameba::Rule::Lint
   # Lint/DuplicatedRequire:
   #   Enabled: true
   # ```
-  struct DuplicatedRequire < Base
+  class DuplicatedRequire < Base
     properties do
       description "Reports duplicated require statements"
     end

--- a/src/ameba/rule/lint/empty_ensure.cr
+++ b/src/ameba/rule/lint/empty_ensure.cr
@@ -38,7 +38,7 @@ module Ameba::Rule::Lint
   # Lint/EmptyEnsure
   #   Enabled: true
   # ```
-  struct EmptyEnsure < Base
+  class EmptyEnsure < Base
     properties do
       description "Disallows empty ensure statement"
     end

--- a/src/ameba/rule/lint/empty_expression.cr
+++ b/src/ameba/rule/lint/empty_expression.cr
@@ -27,7 +27,7 @@ module Ameba::Rule::Lint
   # Lint/EmptyExpression:
   #   Enabled: true
   # ```
-  struct EmptyExpression < Base
+  class EmptyExpression < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/empty_loop.cr
+++ b/src/ameba/rule/lint/empty_loop.cr
@@ -37,7 +37,7 @@ module Ameba::Rule::Lint
   # Lint/EmptyLoop:
   #   Enabled: true
   # ```
-  struct EmptyLoop < Base
+  class EmptyLoop < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/hash_duplicated_key.cr
+++ b/src/ameba/rule/lint/hash_duplicated_key.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Lint
   # Lint/HashDuplicatedKey:
   #   Enabled: true
   # ```
-  struct HashDuplicatedKey < Base
+  class HashDuplicatedKey < Base
     properties do
       description "Disallows duplicated keys in hash literals"
     end

--- a/src/ameba/rule/lint/literal_in_condition.cr
+++ b/src/ameba/rule/lint/literal_in_condition.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Lint
   # Lint/LiteralInCondition:
   #   Enabled: true
   # ```
-  struct LiteralInCondition < Base
+  class LiteralInCondition < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/literal_in_interpolation.cr
+++ b/src/ameba/rule/lint/literal_in_interpolation.cr
@@ -15,7 +15,7 @@ module Ameba::Rule::Lint
   # Lint/LiteralInInterpolation
   #   Enabled: true
   # ```
-  struct LiteralInInterpolation < Base
+  class LiteralInInterpolation < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/percent_array.cr
+++ b/src/ameba/rule/lint/percent_array.cr
@@ -23,7 +23,7 @@ module Ameba::Rule::Lint
   #   StringArrayUnwantedSymbols: ',"'
   #   SymbolArrayUnwantedSymbols: ',:'
   # ```
-  struct PercentArrays < Base
+  class PercentArrays < Base
     properties do
       description "Disallows some unwanted symbols in percent array literals"
 

--- a/src/ameba/rule/lint/rand_zero.cr
+++ b/src/ameba/rule/lint/rand_zero.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Lint
   # Lint/RandZero:
   #   Enabled: true
   # ```
-  struct RandZero < Base
+  class RandZero < Base
     properties do
       description "Disallows rand zero calls"
     end

--- a/src/ameba/rule/lint/redundant_string_coercion.cr
+++ b/src/ameba/rule/lint/redundant_string_coercion.cr
@@ -20,7 +20,7 @@ module Ameba::Rule::Lint
   # Lint/RedundantStringCoersion
   #   Enabled: true
   # ```
-  struct RedundantStringCoercion < Base
+  class RedundantStringCoercion < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/redundant_with_index.cr
+++ b/src/ameba/rule/lint/redundant_with_index.cr
@@ -26,7 +26,7 @@ module Ameba::Rule::Lint
   # Lint/RedundantWithIndex:
   #   Enabled: true
   # ```
-  struct RedundantWithIndex < Base
+  class RedundantWithIndex < Base
     properties do
       description "Disallows redundant `with_index` calls"
     end

--- a/src/ameba/rule/lint/redundant_with_object.cr
+++ b/src/ameba/rule/lint/redundant_with_object.cr
@@ -27,7 +27,7 @@ module Ameba::Rule::Lint
   # Lint/RedundantWithObject:
   #   Enabled: true
   # ```
-  struct RedundantWithObject < Base
+  class RedundantWithObject < Base
     properties do
       description "Disallows redundant `with_object` calls"
     end

--- a/src/ameba/rule/lint/shadowed_argument.cr
+++ b/src/ameba/rule/lint/shadowed_argument.cr
@@ -35,7 +35,7 @@ module Ameba::Rule::Lint
   # Lint/ShadowedArgument:
   #   Enabled: true
   # ```
-  struct ShadowedArgument < Base
+  class ShadowedArgument < Base
     properties do
       description "Disallows shadowed arguments"
     end

--- a/src/ameba/rule/lint/shadowed_exception.cr
+++ b/src/ameba/rule/lint/shadowed_exception.cr
@@ -33,7 +33,7 @@ module Ameba::Rule::Lint
   # Lint/ShadowedException:
   #   Enabled: true
   # ```
-  struct ShadowedException < Base
+  class ShadowedException < Base
     properties do
       description "Disallows rescued exception that get shadowed"
     end

--- a/src/ameba/rule/lint/shadowing_local_outer_var.cr
+++ b/src/ameba/rule/lint/shadowing_local_outer_var.cr
@@ -30,7 +30,7 @@ module Ameba::Rule::Lint
   # Lint/ShadowingOuterLocalVar:
   #   Enabled: true
   # ```
-  struct ShadowingOuterLocalVar < Base
+  class ShadowingOuterLocalVar < Base
     properties do
       description "Disallows the usage of the same name as outer local variables" \
                   " for block or proc arguments."

--- a/src/ameba/rule/lint/shared_var_in_fiber.cr
+++ b/src/ameba/rule/lint/shared_var_in_fiber.cr
@@ -49,7 +49,7 @@ module Ameba::Rule::Lint
   # Lint/SharedVarInFiber:
   #   Enabled: true
   # ```
-  struct SharedVarInFiber < Base
+  class SharedVarInFiber < Base
     properties do
       description "Disallows shared variables in fibers."
     end

--- a/src/ameba/rule/lint/syntax.cr
+++ b/src/ameba/rule/lint/syntax.cr
@@ -18,7 +18,7 @@ module Ameba::Rule::Lint
   # rescue e : Exception
   # end
   # ```
-  struct Syntax < Base
+  class Syntax < Base
     properties do
       description "Reports invalid Crystal syntax"
       severity Ameba::Severity::Error

--- a/src/ameba/rule/lint/unneeded_disable_directive.cr
+++ b/src/ameba/rule/lint/unneeded_disable_directive.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Lint
   # Lint/UnneededDisableDirective
   #   Enabled: true
   # ```
-  struct UnneededDisableDirective < Base
+  class UnneededDisableDirective < Base
     properties do
       description "Reports unneeded disable directives in comments"
     end

--- a/src/ameba/rule/lint/unreachable_code.cr
+++ b/src/ameba/rule/lint/unreachable_code.cr
@@ -41,7 +41,7 @@ module Ameba::Rule::Lint
   # Lint/UnreachableCode:
   #   Enabled: true
   # ```
-  struct UnreachableCode < Base
+  class UnreachableCode < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/lint/unused_argument.cr
+++ b/src/ameba/rule/lint/unused_argument.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Lint
   #   IgnoreBlocks: false
   #   IgnoreProcs: false
   # ```
-  struct UnusedArgument < Base
+  class UnusedArgument < Base
     properties do
       description "Disallows unused arguments"
 

--- a/src/ameba/rule/lint/useless_assign.cr
+++ b/src/ameba/rule/lint/useless_assign.cr
@@ -25,7 +25,7 @@ module Ameba::Rule::Lint
   # Lint/UselessAssign:
   #   Enabled: true
   # ```
-  struct UselessAssign < Base
+  class UselessAssign < Base
     properties do
       description "Disallows useless variable assignments"
     end

--- a/src/ameba/rule/lint/useless_condition_in_when.cr
+++ b/src/ameba/rule/lint/useless_condition_in_when.cr
@@ -30,7 +30,7 @@ module Ameba::Rule::Lint
   # Lint/UselessConditionInWhen:
   #   Enabled: true
   # ```
-  struct UselessConditionInWhen < Base
+  class UselessConditionInWhen < Base
     properties do
       description "Disallows useless conditions in when"
     end

--- a/src/ameba/rule/metrics/cyclomatic_complexity.cr
+++ b/src/ameba/rule/metrics/cyclomatic_complexity.cr
@@ -8,7 +8,7 @@ module Ameba::Rule::Metrics
   #   Enabled: true
   #   MaxComplexity: 10
   # ```
-  struct CyclomaticComplexity < Base
+  class CyclomaticComplexity < Base
     properties do
       description "Disallows methods with a cyclomatic complexity higher than `MaxComplexity`"
       max_complexity 10

--- a/src/ameba/rule/performance/any_after_filter.cr
+++ b/src/ameba/rule/performance/any_after_filter.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Performance
   #     - select
   #     - reject
   # ```
-  struct AnyAfterFilter < Base
+  class AnyAfterFilter < Base
     properties do
       description "Identifies usage of `any?` calls that follow filters."
       filter_names : Array(String) = %w(select reject)

--- a/src/ameba/rule/performance/compact_after_map.cr
+++ b/src/ameba/rule/performance/compact_after_map.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Performance
   # Performance/CompactAfterMap
   #   Enabled: true
   # ```
-  struct CompactAfterMap < Base
+  class CompactAfterMap < Base
     properties do
       description "Identifies usage of `compact` calls that follow `map`."
     end

--- a/src/ameba/rule/performance/first_last_after_filter.cr
+++ b/src/ameba/rule/performance/first_last_after_filter.cr
@@ -23,7 +23,7 @@ module Ameba::Rule::Performance
   #   FilterNames:
   #     - select
   # ```
-  struct FirstLastAfterFilter < Base
+  class FirstLastAfterFilter < Base
     properties do
       description "Identifies usage of `first/last/first?/last?` calls that follow filters."
       filter_names : Array(String) = %w(select)

--- a/src/ameba/rule/performance/flatten_after_map.cr
+++ b/src/ameba/rule/performance/flatten_after_map.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Performance
   # Performance/FlattenAfterMap
   #   Enabled: true
   # ```
-  struct FlattenAfterMap < Base
+  class FlattenAfterMap < Base
     properties do
       description "Identifies usage of `flatten` calls that follow `map`."
     end

--- a/src/ameba/rule/performance/map_instead_of_block.cr
+++ b/src/ameba/rule/performance/map_instead_of_block.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Performance
   # Performance/MapInsteadOfBlock
   #   Enabled: true
   # ```
-  struct MapInsteadOfBlock < Base
+  class MapInsteadOfBlock < Base
     properties do
       description "Identifies usage of `join/sum/product` calls that follow `map`."
     end

--- a/src/ameba/rule/performance/size_after_filter.cr
+++ b/src/ameba/rule/performance/size_after_filter.cr
@@ -30,7 +30,7 @@ module Ameba::Rule::Performance
   #     - select
   #     - reject
   # ```
-  struct SizeAfterFilter < Base
+  class SizeAfterFilter < Base
     properties do
       description "Identifies usage of `size` calls that follow filter"
       filter_names : Array(String) = %w(select reject)

--- a/src/ameba/rule/style/constant_names.cr
+++ b/src/ameba/rule/style/constant_names.cr
@@ -21,7 +21,7 @@ module Ameba::Rule::Style
   # Style/ConstantNames:
   #   Enabled: true
   # ```
-  struct ConstantNames < Base
+  class ConstantNames < Base
     properties do
       description "Enforces constant names to be in screaming case"
     end

--- a/src/ameba/rule/style/is_a_nil.cr
+++ b/src/ameba/rule/style/is_a_nil.cr
@@ -19,7 +19,7 @@ module Ameba::Rule::Style
   # Style/IsANil:
   #   Enabled: true
   # ```
-  struct IsANil < Base
+  class IsANil < Base
     properties do
       description "Disallows calls to `is_a?(Nil)` in favor of `nil?`"
     end

--- a/src/ameba/rule/style/large_numbers.cr
+++ b/src/ameba/rule/style/large_numbers.cr
@@ -26,7 +26,7 @@ module Ameba::Rule::Style
   #   Enabled: true
   #   IntMinDigits: 5 # i.e. integers higher than 9999
   # ```
-  struct LargeNumbers < Base
+  class LargeNumbers < Base
     properties do
       enabled false
       description "Disallows usage of large numbers without underscore"

--- a/src/ameba/rule/style/method_names.cr
+++ b/src/ameba/rule/style/method_names.cr
@@ -37,7 +37,7 @@ module Ameba::Rule::Style
   # Style/MethodNames:
   #   Enabled: true
   # ```
-  struct MethodNames < Base
+  class MethodNames < Base
     properties do
       description "Enforces method names to be in underscored case"
     end

--- a/src/ameba/rule/style/negated_conditions_in_unless.cr
+++ b/src/ameba/rule/style/negated_conditions_in_unless.cr
@@ -26,7 +26,7 @@ module Ameba::Rule::Style
   # Style/NegatedConditionsInUnless:
   #   Enabled: true
   # ```
-  struct NegatedConditionsInUnless < Base
+  class NegatedConditionsInUnless < Base
     properties do
       description "Disallows negated conditions in unless"
     end

--- a/src/ameba/rule/style/predicate_name.cr
+++ b/src/ameba/rule/style/predicate_name.cr
@@ -28,7 +28,7 @@ module Ameba::Rule::Style
   # Style/PredicateName:
   #   Enabled: true
   # ```
-  struct PredicateName < Base
+  class PredicateName < Base
     properties do
       enabled false
       description "Disallows tautological predicate names"

--- a/src/ameba/rule/style/redundant_begin.cr
+++ b/src/ameba/rule/style/redundant_begin.cr
@@ -55,7 +55,7 @@ module Ameba::Rule::Style
   # Style/RedundantBegin:
   #   Enabled: true
   # ```
-  struct RedundantBegin < Base
+  class RedundantBegin < Base
     include AST::Util
 
     properties do

--- a/src/ameba/rule/style/redundant_next.cr
+++ b/src/ameba/rule/style/redundant_next.cr
@@ -96,7 +96,7 @@ module Ameba::Rule::Style
   #   AllowMultiNext: true
   #   AllowEmptyNext: true
   # ```
-  struct RedundantNext < Base
+  class RedundantNext < Base
     properties do
       description "Reports redundant next expressions"
 

--- a/src/ameba/rule/style/redundant_return.cr
+++ b/src/ameba/rule/style/redundant_return.cr
@@ -93,7 +93,7 @@ module Ameba::Rule::Style
   #   AllowMutliReturn: true
   #   AllowEmptyReturn: true
   # ```
-  struct RedundantReturn < Base
+  class RedundantReturn < Base
     properties do
       description "Reports redundant return expressions"
 

--- a/src/ameba/rule/style/type_names.cr
+++ b/src/ameba/rule/style/type_names.cr
@@ -51,7 +51,7 @@ module Ameba::Rule::Style
   # Style/TypeNames:
   #   Enabled: true
   # ```
-  struct TypeNames < Base
+  class TypeNames < Base
     properties do
       description "Enforces type names in camelcase manner"
     end

--- a/src/ameba/rule/style/unless_else.cr
+++ b/src/ameba/rule/style/unless_else.cr
@@ -42,7 +42,7 @@ module Ameba::Rule::Style
   # Style/UnlessElse:
   #   Enabled: true
   # ```
-  struct UnlessElse < Base
+  class UnlessElse < Base
     properties do
       description "Disallows the use of an `else` block with the `unless`"
     end

--- a/src/ameba/rule/style/variable_names.cr
+++ b/src/ameba/rule/style/variable_names.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Style
   # Style/VariableNames:
   #   Enabled: true
   # ```
-  struct VariableNames < Base
+  class VariableNames < Base
     properties do
       description "Enforces variable names to be in underscored case"
     end

--- a/src/ameba/rule/style/while_true.cr
+++ b/src/ameba/rule/style/while_true.cr
@@ -25,7 +25,7 @@ module Ameba::Rule::Style
   # Style/WhileTrue:
   #   Enabled: true
   # ```
-  struct WhileTrue < Base
+  class WhileTrue < Base
     properties do
       description "Disallows while statements with a true literal as condition"
     end


### PR DESCRIPTION
Due to `Rule`s having at least one `Array` ivar and being manipulated pretty often, turning it into a class instead should yield performance improvement. It also allows to simplify the code around rule handling.