### PR TITLE
Add Performance/FlattenAfterMap rule

### DIFF
--- a/spec/ameba/rule/performance/flatten_after_map_spec.cr
+++ b/spec/ameba/rule/performance/flatten_after_map_spec.cr
@@ -1,0 +1,43 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Performance
+  subject = FlattenAfterMap.new
+
+  describe FlattenAfterMap do
+    it "passes if there is no potential performance improvements" do
+      source = Source.new %(
+        %w[Alice Bob].flat_map(&.chars)
+      )
+      subject.catch(source).should be_valid
+    end
+
+    it "reports if there is map followed by flatten call" do
+      source = Source.new %(
+        %w[Alice Bob].map(&.chars).flatten
+      )
+      subject.catch(source).should_not be_valid
+    end
+
+    context "macro" do
+      it "doesn't report in macro scope" do
+        source = Source.new %(
+          {{ %w[Alice Bob].map(&.chars).flatten }}
+        )
+        subject.catch(source).should be_valid
+      end
+    end
+
+    it "reports rule, pos and message" do
+      s = Source.new %(
+        %w[Alice Bob].map(&.chars).flatten
+      ), "source.cr"
+      subject.catch(s).should_not be_valid
+      issue = s.issues.first
+
+      issue.rule.should_not be_nil
+      issue.location.to_s.should eq "source.cr:1:15"
+      issue.end_location.to_s.should eq "source.cr:1:35"
+      issue.message.should eq "Use `flat_map {...}` instead of `map {...}.flatten`"
+    end
+  end
+end

--- a/src/ameba/rule/performance/flatten_after_map.cr
+++ b/src/ameba/rule/performance/flatten_after_map.cr
@@ -1,0 +1,48 @@
+module Ameba::Rule::Performance
+  # This rule is used to identify usage of `flatten` calls that follow `map`.
+  #
+  # For example, this is considered inefficient:
+  #
+  # ```
+  # %w[Alice Bob].map(&.chars).flatten
+  # ```
+  #
+  # And can be written as this:
+  #
+  # ```
+  # %w[Alice Bob].flat_map(&.chars)
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Performance/FlattenAfterMap
+  #   Enabled: true
+  # ```
+  struct FlattenAfterMap < Base
+    properties do
+      description "Identifies usage of `flatten` calls that follow `map`."
+    end
+
+    FLATTEN_NAME = "flatten"
+    MAP_NAME     = "map"
+    MSG          = "Use `flat_map {...}` instead of `map {...}.flatten`"
+
+    def test(source)
+      AST::NodeVisitor.new self, source, skip: [
+        Crystal::Macro,
+        Crystal::MacroExpression,
+        Crystal::MacroIf,
+        Crystal::MacroFor,
+      ]
+    end
+
+    def test(source, node : Crystal::Call)
+      return unless node.name == FLATTEN_NAME && (obj = node.obj)
+      return unless obj.is_a?(Crystal::Call) && obj.block
+      return unless obj.name == MAP_NAME
+
+      issue_for obj.name_location, node.name_end_location, MSG
+    end
+  end
+end


### PR DESCRIPTION
`Enumerable#flat_map` saves one iteration vs `map` + `flatten`.