### PR TITLE
ChainedCallsWithNoBang -> ChainedCallWithNoBang

### DIFF
--- a/spec/ameba/rule/performance/chained_call_with_no_bang_spec.cr
+++ b/spec/ameba/rule/performance/chained_call_with_no_bang_spec.cr
@@ -1,9 +1,9 @@
 require "../../../spec_helper"
 
 module Ameba::Rule::Performance
-  subject = ChainedCallsWithNoBang.new
+  subject = ChainedCallWithNoBang.new
 
-  describe ChainedCallsWithNoBang do
+  describe ChainedCallWithNoBang do
     it "passes if there is no potential performance improvements" do
       source = Source.new %(
         (1..3).select { |e| e > 1 }.sort!
@@ -35,7 +35,7 @@ module Ameba::Rule::Performance
         source = Source.new %(
           [1, 2, 3].select { |e| e > 2 }.reverse
         )
-        rule = ChainedCallsWithNoBang.new
+        rule = ChainedCallWithNoBang.new
         rule.call_names = %w(uniq)
         rule.catch(source).should be_valid
       end

--- a/src/ameba/rule/performance/chained_call_with_no_bang.cr
+++ b/src/ameba/rule/performance/chained_call_with_no_bang.cr
@@ -25,7 +25,7 @@ module Ameba::Rule::Performance
   # YAML configuration example:
   #
   # ```
-  # Performance/ChainedCallsWithNoBang
+  # Performance/ChainedCallWithNoBang
   #   Enabled: true
   #   CallNames:
   #     - uniq
@@ -34,7 +34,7 @@ module Ameba::Rule::Performance
   #     - shuffle
   #     - reverse
   # ```
-  class ChainedCallsWithNoBang < Base
+  class ChainedCallWithNoBang < Base
     properties do
       description "Identifies usage of chained calls not utilizing the bang method variants."
 


### PR DESCRIPTION
Just noticed this rule is not named like the others (ie. in singular form).