### PR TITLE
Avoid exponential recursion while finding variable references in scopes

### DIFF
--- a/spec/ameba/rule/lint/useless_assign_spec.cr
+++ b/spec/ameba/rule/lint/useless_assign_spec.cr
@@ -1006,6 +1006,47 @@ module Ameba::Rule::Lint
       end
     end
 
+    it "does not report if variable is referenced and there is a deep level scope" do
+      s = Source.new %(
+        response = JSON.build do |json|
+          json.object do
+            json.object do
+              json.object do
+                json.object do
+                  json.object do
+                    json.object do
+                      json.object do
+                        json.object do
+                          json.object do
+                            json.object do
+                              json.object do
+                                json.object do
+                                  json.object do
+                                    json.object do
+                                      anything
+                                    end
+                                  end
+                                end
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        response = JSON.parse(response)
+        response = prepare(response)
+        response
+       )
+      subject.catch(s).should be_valid
+    end
+
     context "uninitialized" do
       it "reports if uninitialized assignment is not referenced at a top level" do
         s = Source.new %(

--- a/spec/ameba/rule/lint/useless_assign_spec.cr
+++ b/spec/ameba/rule/lint/useless_assign_spec.cr
@@ -1023,7 +1023,9 @@ module Ameba::Rule::Lint
                                 json.object do
                                   json.object do
                                     json.object do
-                                      anything
+                                      json.object do
+                                        anything
+                                      end
                                     end
                                   end
                                 end
@@ -1041,7 +1043,6 @@ module Ameba::Rule::Lint
         end
 
         response = JSON.parse(response)
-        response = prepare(response)
         response
        )
       subject.catch(s).should be_valid

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -134,10 +134,10 @@ module Ameba::AST
 
     # Returns true if current scope (or any of inner scopes) references variable,
     # false if not.
-    def references?(variable : Variable)
+    def references?(variable : Variable, check_inner_scopes = true)
       variable.references.any? do |reference|
-        reference.scope == self ||
-          inner_scopes.any?(&.references? variable)
+        return true if reference.scope == self
+        check_inner_scopes && inner_scopes.any?(&.references?(variable))
       end || variable.used_in_macro?
     end
 

--- a/src/ameba/ast/variabling/variable.cr
+++ b/src/ameba/ast/variabling/variable.cr
@@ -113,7 +113,7 @@ module Ameba::AST
     # ```
     def captured_by_block?(scope = @scope)
       scope.inner_scopes.each do |inner_scope|
-        return true if inner_scope.block? && inner_scope.references?(self)
+        return true if inner_scope.block? && inner_scope.references?(self, check_inner_scopes: false)
         return true if captured_by_block?(inner_scope)
       end
 

--- a/src/ameba/rule/lint/useless_assign.cr
+++ b/src/ameba/rule/lint/useless_assign.cr
@@ -39,7 +39,7 @@ module Ameba::Rule::Lint
 
     def test(source, node, scope : AST::Scope)
       scope.variables.each do |var|
-        next if var.captured_by_block? || var.used_in_macro? || var.ignored?
+        next if var.ignored? || var.used_in_macro? || var.captured_by_block?
 
         var.assignments.each do |assign|
           next if assign.referenced? || assign.transformed?


### PR DESCRIPTION

closes #177 

### Before:

```sh
$ invidious git:master ❯ ameba --only Lint/UselessAssign src/invidious.cr 
Inspecting 1 file.

... hangs out
```

### After:

```sh
$ invidious git:master ❯ ameba --only Lint/UselessAssign src/invidious.cr                               ✭
Inspecting 1 file.

F

src/invidious.cr:407:3
[W] Lint/UselessAssign: Useless assignment to variable `locale`
> locale = LOCALES[env.get("preferences").as(Preferences).locale]?
  ^
src/invidious.cr:410:3
[W] Lint/UselessAssign: Useless assignment to variable `sid`
> sid = env.get? "sid"

...

Finished in 5.89 seconds

1 inspected, 77 failures.
```


---

