### PR TITLE
Default to exclude_multiple_line_blocks in Style/VerboseBlock rule

### DIFF
--- a/spec/ameba/rule/style/verbose_block_spec.cr
+++ b/spec/ameba/rule/style/verbose_block_spec.cr
@@ -128,6 +128,7 @@ module Ameba::Rule::Style
           end
         )
         rule = VerboseBlock.new
+          .tap(&.exclude_multiple_line_blocks = false)
         rule
           .tap(&.max_line_length = 60)
           .catch(source).should be_valid

--- a/src/ameba/rule/style/verbose_block.cr
+++ b/src/ameba/rule/style/verbose_block.cr
@@ -20,7 +20,7 @@ module Ameba::Rule::Style
   # Style/VerboseBlock:
   #   Enabled: true
   #   ExcludeMultipleLineBlocks: true
-  #   ExcludeCallsWithBlocks: false
+  #   ExcludeCallsWithBlocks: true
   #   ExcludePrefixOperators: true
   #   ExcludeOperators: false
   #   ExcludeSetters: false
@@ -31,8 +31,8 @@ module Ameba::Rule::Style
     properties do
       description "Identifies usage of collapsible single expression blocks."
 
+      exclude_multiple_line_blocks true
       exclude_calls_with_block true
-      exclude_multiple_line_blocks false
       exclude_prefix_operators true
       exclude_operators false
       exclude_setters false


### PR DESCRIPTION
I've found this to be a better default for many of the shards, as - especially in specs - multiline blocks are purposefully made to be that way leading to some overeagerness in application.