### PR TITLE
Follow crystal 1.0.0 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,6 @@ scripts:
 executables:
   - ameba
 
-crystal: ">= 0.35.0"
+crystal: ">= 0.35.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
```console
$ crystal --version
Crystal 1.0.0 (2021-03-22)

LLVM: 9.0.1
Default target: x86_64-apple-macosx

$ crystal spec
................................................................................................................................
................................................................................................................................
................................................................................................................................
................................................................................................................................
................................................................................................................................
................................................................................................................................
................................................................................................................................
..................................................................................

Finished in 341.43 milliseconds
978 examples, 0 failures, 0 errors, 0 pending
```

So I think this shard will work in crystal 1.0.0 ☺️
But user using crystal 1.0.0 and shards 0.14.1 raises an error when `--ignore-crystal-version` not given.

So this change might reduce the annoying error for shards users? 🤔

https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/docs/shard.yml.adoc

>When just a version number is used it has a different semantic compared to dependencies: x.y.z will be interpreted as ~> x.y, >= x.y.z (ie: >= x.y.z, < (x+1).0.0) honoring semver.