### PR TITLE
Revert "Follow crystal 1.0.0 in shard.yml"

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,6 @@ scripts:
 executables:
   - ameba
 
-crystal: ">= 0.35.0, < 2.0.0"
+crystal: ">= 0.35.0"
 
 license: MIT


### PR DESCRIPTION
Reverts crystal-ameba/ameba#215

https://github.com/crystal-ameba/ameba/pull/215#issuecomment-805137536

Sorry it came from my misunderstanding for the `shard.yml` spec 🙇 
If reverting is needed, please merge, sorry for making messy commit history 🙏 

---

FYI: I'm asking a recommended specifying via https://github.com/crystal-lang/shards/pull/487 😅 



