### PR TITLE
Count an exhaustive `case` complexity as 1

### DIFF
--- a/spec/ameba/ast/visitors/counting_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/counting_visitor_spec.cr
@@ -48,8 +48,8 @@ module Ameba::AST
         code = %(
           def hello(a : Int32 | Int64 | Float32 | Float64)
             case a
-            in Int32 then "int32"
-            in Int64 then "int64"
+            in Int32   then "int32"
+            in Int64   then "int64"
             in Float32 then "float32"
             in Float64 then "float64"
             end

--- a/src/ameba/ast/visitors/counting_visitor.cr
+++ b/src/ameba/ast/visitors/counting_visitor.cr
@@ -32,10 +32,12 @@ module Ameba::AST
 
     # :nodoc:
     def visit(node : Crystal::Case)
+      return true if macro_condition
+
       # Count the complexity of an exhaustive `Case` as 1
       # Otherwise count the number of `When`s
-      case_complexity = node.exhaustive? ? 1 : node.whens.size
-      @complexity += case_complexity unless macro_condition
+      @complexity += node.exhaustive? ? 1 : node.whens.size
+
       true
     end
 

--- a/src/ameba/ast/visitors/counting_visitor.cr
+++ b/src/ameba/ast/visitors/counting_visitor.cr
@@ -23,12 +23,21 @@ module Ameba::AST
     # Uses the same logic than rubocop. See
     # https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/metrics/cyclomatic_complexity.rb#L21
     # Except "for", because crystal doesn't have a "for" loop.
-    {% for node in %i(if while until rescue when or and) %}
+    {% for node in %i(if while until rescue or and) %}
       # :nodoc:
       def visit(node : Crystal::{{ node.id.capitalize }})
         @complexity += 1 unless macro_condition
       end
     {% end %}
+
+    # :nodoc:
+    def visit(node : Crystal::Case)
+      # Count the complexity of an exhaustive `Case` as 1
+      # Otherwise count the number of `When`s
+      case_complexity = node.exhaustive? ? 1 : node.whens.size
+      @complexity += case_complexity unless macro_condition
+      true
+    end
 
     def visit(node : Crystal::MacroIf | Crystal::MacroFor)
       @macro_condition = true


### PR DESCRIPTION
Methods with exhaustive cases over enums triggering false positives for cyclomatic complexity.
For example, one may have a state machine where an exhaustive case over enum members is used to dispatch to methods.

This PR counts an exhaustive case's complexity as 1, otherwise treats an inexhaustive case's `when`s as it did previously.