### PR TITLE
Fix unexpected token compiler error match

### DIFF
--- a/spec/ameba/rule/lint/syntax_spec.cr
+++ b/spec/ameba/rule/lint/syntax_spec.cr
@@ -31,7 +31,7 @@ module Ameba::Rule::Lint
 
       issue.rule.should_not be_nil
       issue.location.to_s.should eq "source.cr:1:11"
-      issue.message.should eq "unexpected token: end (expected ';' or newline)"
+      issue.message.should match /unexpected token: "?end"? \(expected ["'];["'] or newline\)/
     end
 
     it "has highest severity" do


### PR DESCRIPTION
After https://github.com/crystal-lang/crystal/pull/11473 the following spec in ameba's spec suite is broken:

```
   1) Ameba::Rule::Lint::Syntax reports rule, location and message
      Failure/Error: issue.message.should eq "unexpected token: end (expected ';' or newline)"

        Expected: "unexpected token: end (expected ';' or newline)"
             got: "unexpected token: \"end\" (expected \";\" or newline)"
 
      # spec/ameba/rule/lint/syntax_spec.cr:34
```