### PR TITLE
Add `Lint/DebugCalls` rule

### DIFF
--- a/spec/ameba/rule/lint/debug_calls_spec.cr
+++ b/spec/ameba/rule/lint/debug_calls_spec.cr
@@ -1,0 +1,43 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  subject = DebugCalls.new
+
+  describe DebugCalls do
+    it "fails if there is a debug call" do
+      subject.method_names.each do |name|
+        source = expect_issue subject, <<-CRYSTAL, name: name
+          a = 2
+          %{name} a
+          # ^{name} error: Possibly forgotten debug-related `%{name}` call detected
+          a = a + 1
+          CRYSTAL
+
+        expect_no_corrections source
+      end
+    end
+
+    it "passes if there is no debug call" do
+      subject.method_names.each do |name|
+        expect_no_issues subject, <<-CRYSTAL
+          class A
+            def #{name}
+            end
+          end
+          A.new.#{name}
+          CRYSTAL
+      end
+    end
+
+    it "reports rule, pos and message" do
+      s = Source.new "pp! :foo", "source.cr"
+      subject.catch(s).should_not be_valid
+
+      issue = s.issues.first
+      issue.rule.should_not be_nil
+      issue.location.to_s.should eq "source.cr:1:1"
+      issue.end_location.to_s.should eq "source.cr:1:8"
+      issue.message.should eq "Possibly forgotten debug-related `pp!` call detected"
+    end
+  end
+end

--- a/src/ameba/rule/lint/debug_calls.cr
+++ b/src/ameba/rule/lint/debug_calls.cr
@@ -1,0 +1,32 @@
+module Ameba::Rule::Lint
+  # A rule that disallows calls to debug-related methods.
+  #
+  # This is because we don't want debug calls accidentally being
+  # committed into our codebase.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/DebugCalls:
+  #   Enabled: true
+  #   MethodNames:
+  #     - p
+  #     - p!
+  #     - pp
+  #     - pp!
+  # ```
+  class DebugCalls < Base
+    properties do
+      description "Disallows debug-related calls"
+      method_names : Array(String) = %w(p p! pp pp!)
+    end
+
+    MSG = "Possibly forgotten debug-related `%s` call detected"
+
+    def test(source, node : Crystal::Call)
+      return unless node.name.in?(method_names) && node.obj.nil?
+
+      issue_for node, MSG % node.name
+    end
+  end
+end


### PR DESCRIPTION
Adds support for catching `pp` (et al) calls.