### PR TITLE
Disable `Style/LargeNumbers` rule by default

### DIFF
--- a/src/ameba/rule/style/large_numbers.cr
+++ b/src/ameba/rule/style/large_numbers.cr
@@ -28,7 +28,7 @@ module Ameba::Rule::Style
   # ```
   class LargeNumbers < Base
     properties do
-      enabled true
+      enabled false
       description "Disallows usage of large numbers without underscore"
       int_min_digits 5
     end


### PR DESCRIPTION
Reverts part of e5fb0526e0ead371d50e9cdb2b14a93fcb0ad868