### PR TITLE
Bump default value of `LargeNumbers#int_min_digits` to 6

### DIFF
--- a/spec/ameba/rule/style/large_numbers_spec.cr
+++ b/spec/ameba/rule/style/large_numbers_spec.cr
@@ -6,6 +6,7 @@ module Ameba
   private def it_transforms(number, expected)
     it "transforms large number #{number}" do
       rule = Rule::Style::LargeNumbers.new
+      rule.int_min_digits = 5
 
       source = expect_issue rule, <<-CRYSTAL, number: number
         number = %{number}

--- a/src/ameba/rule/style/large_numbers.cr
+++ b/src/ameba/rule/style/large_numbers.cr
@@ -6,17 +6,17 @@ module Ameba::Rule::Style
   # For example, these are considered invalid:
   #
   # ```
-  # 10000
+  # 100000
   # 141592654
-  # 5.12345
+  # 5.123456
   # ```
   #
   # And has to be rewritten as the following:
   #
   # ```
-  # 10_000
+  # 100_000
   # 141_592_654
-  # 5.123_45
+  # 5.123_456
   # ```
   #
   # YAML configuration example:
@@ -24,13 +24,13 @@ module Ameba::Rule::Style
   # ```
   # Style/LargeNumbers:
   #   Enabled: true
-  #   IntMinDigits: 5 # i.e. integers higher than 9999
+  #   IntMinDigits: 6 # i.e. integers higher than 99999
   # ```
   class LargeNumbers < Base
     properties do
       enabled true
       description "Disallows usage of large numbers without underscore"
-      int_min_digits 5
+      int_min_digits 6
     end
 
     MSG = "Large numbers should be written with underscores: %s"


### PR DESCRIPTION
As most of the error codes are smaller than 6 digits
Ref https://github.com/crystal-ameba/ameba/pull/257#issuecomment-1060798162