### PR TITLE
Change `crystal` version constraint to `~> 1.4.0`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,6 @@ scripts:
 executables:
   - ameba
 
-crystal: ">= 1.4.0"
+crystal: "~> 1.4.0"
 
 license: MIT


### PR DESCRIPTION
Uses a more conservative, yet still flexible approach to Crystal version compatibility.