### PR TITLE
Fix regression in `AnyInsteadOfEmpty` rule

### DIFF
--- a/spec/ameba/rule/performance/any_instead_of_empty_spec.cr
+++ b/spec/ameba/rule/performance/any_instead_of_empty_spec.cr
@@ -16,7 +16,7 @@ module Ameba::Rule::Performance
     it "reports if there is any? call without a block nor argument" do
       source = expect_issue subject, <<-CRYSTAL
         [1, 2, 3].any?
-        # ^^^^^^^^^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
+                # ^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
         CRYSTAL
 
       expect_correction source, <<-CRYSTAL
@@ -34,7 +34,7 @@ module Ameba::Rule::Performance
       it "reports in macro scope" do
         source = expect_issue subject, <<-CRYSTAL
           {{ [1, 2, 3].any? }}
-           # ^^^^^^^^^^^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
+                     # ^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
           CRYSTAL
 
         expect_correction source, <<-CRYSTAL
@@ -51,7 +51,7 @@ module Ameba::Rule::Performance
       issue = source.issues.first
 
       issue.rule.should_not be_nil
-      issue.location.to_s.should eq "source.cr:1:1"
+      issue.location.to_s.should eq "source.cr:1:11"
       issue.end_location.to_s.should eq "source.cr:1:14"
       issue.message.should eq "Use `!{...}.empty?` instead of `{...}.any?`"
     end

--- a/src/ameba/rule/performance/any_instead_of_empty.cr
+++ b/src/ameba/rule/performance/any_instead_of_empty.cr
@@ -45,7 +45,7 @@ module Ameba::Rule::Performance
       return unless name_location = node.name_location
       return unless end_location = name_end_location(node)
 
-      issue_for location, end_location, MSG do |corrector|
+      issue_for name_location, end_location, MSG do |corrector|
         corrector.insert_before(location, '!')
         corrector.replace(name_location, end_location, "empty?")
       end


### PR DESCRIPTION
Fixes #267 regression (introduced in [`63a6c73`](https://github.com/crystal-ameba/ameba/commit/63a6c73dc0549d5091016dcc1aa74d4d747269f5#diff-7e35ef9fecf1900c60df38cce289a5265975e26bcbf07f485d84f8af50f87a1dL43-R48) as a part of #253)