### PR TITLE
fix restriction issue

### DIFF
--- a/src/ameba/inline_comments.cr
+++ b/src/ameba/inline_comments.cr
@@ -36,7 +36,7 @@ module Ameba
     #   Time.epoch(1483859302)
     # end
     # ```
-    def location_disabled?(location, rule)
+    def location_disabled?(location : Crystal::Location?, rule)
       return false if rule.name.in?(Rule::SPECIAL)
       return false unless line_number = location.try &.line_number.try &.- 1
       return false unless line = lines[line_number]?

--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -7,8 +7,8 @@ module Ameba
     # Adds a new issue to the list of issues.
     def add_issue(rule,
                   location : Crystal::Location?,
-                  end_location,
-                  message,
+                  end_location : Crystal::Location?,
+                  message : String,
                   status : Issue::Status? = nil,
                   block : (Source::Corrector ->)? = nil) : Issue
       status ||=

--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -5,7 +5,7 @@ module Ameba
     getter issues = [] of Issue
 
     # Adds a new issue to the list of issues.
-    def add_issue(rule, location, end_location, message, status : Issue::Status? = nil, block : (Source::Corrector ->)? = nil) : Issue
+    def add_issue(rule, location : Crystal::Location?, end_location, message, status : Issue::Status? = nil, block : (Source::Corrector ->)? = nil) : Issue
       status ||=
         Issue::Status::Disabled if location_disabled?(location, rule)
 
@@ -15,7 +15,7 @@ module Ameba
     end
 
     # :ditto:
-    def add_issue(rule, location, end_location, message, status : Issue::Status? = nil, &block : Source::Corrector ->) : Issue
+    def add_issue(rule, location : Crystal::Location, end_location, message, status : Issue::Status? = nil, &block : Source::Corrector ->) : Issue
       add_issue rule, location, end_location, message, status, block
     end
 

--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -22,7 +22,7 @@ module Ameba
     # :ditto:
     def add_issue(rule,
                   location : Crystal::Location,
-                  end_location : Crystal::Location?,
+                  end_location : Crystal::Location,
                   message : String,
                   status : Issue::Status? = nil,
                   &block : Source::Corrector ->) : Issue

--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -22,8 +22,8 @@ module Ameba
     # :ditto:
     def add_issue(rule,
                   location : Crystal::Location,
-                  end_location,
-                  message,
+                  end_location : Crystal::Location?,
+                  message : String,
                   status : Issue::Status? = nil,
                   &block : Source::Corrector ->) : Issue
       add_issue rule, location, end_location, message, status, block

--- a/src/ameba/reportable.cr
+++ b/src/ameba/reportable.cr
@@ -5,7 +5,12 @@ module Ameba
     getter issues = [] of Issue
 
     # Adds a new issue to the list of issues.
-    def add_issue(rule, location : Crystal::Location?, end_location, message, status : Issue::Status? = nil, block : (Source::Corrector ->)? = nil) : Issue
+    def add_issue(rule,
+                  location : Crystal::Location?,
+                  end_location,
+                  message,
+                  status : Issue::Status? = nil,
+                  block : (Source::Corrector ->)? = nil) : Issue
       status ||=
         Issue::Status::Disabled if location_disabled?(location, rule)
 
@@ -15,7 +20,12 @@ module Ameba
     end
 
     # :ditto:
-    def add_issue(rule, location : Crystal::Location, end_location, message, status : Issue::Status? = nil, &block : Source::Corrector ->) : Issue
+    def add_issue(rule,
+                  location : Crystal::Location,
+                  end_location,
+                  message,
+                  status : Issue::Status? = nil,
+                  &block : Source::Corrector ->) : Issue
       add_issue rule, location, end_location, message, status, block
     end
 


### PR DESCRIPTION
caused by https://github.com/crystal-lang/crystal/pull/12335

Ameba fails on Crystal Nightly. For example https://github.com/mamantoha/crest/runs/7602787403?check_suite_focus=true

```
In src/ameba/inline_comments.cr:41:56

 41 | return false unless line_number = location.try &.line_number.try &.- 1
                                                       ^----------
Error: Error: undefined method 'line_number' for Tuple(Int32, Int32)

make: *** [Makefile:8: bin/ameba] Error 1
```