### PR TITLE
Crystal::Keyword not available

### DIFF
--- a/src/ameba/rule/style/redundant_begin.cr
+++ b/src/ameba/rule/style/redundant_begin.cr
@@ -123,7 +123,7 @@ module Ameba::Rule::Style
           break
         when .ident?
           next unless in_body
-          return unless token.value == Crystal::Keyword::BEGIN
+          return unless token.value.begin?
           return token.location
         when .op_lparen?
           in_argument_list = true
@@ -143,7 +143,7 @@ module Ameba::Rule::Style
       end_loc = def_end_loc = nil
 
       Tokenizer.new(lexer).run do |token|
-        next unless token.value == Crystal::Keyword::END
+        next unless token.value.end?
 
         end_loc, def_end_loc = def_end_loc, token.location
       end


### PR DESCRIPTION
Hello! I have some error's with build new version on linux.

Here is binary crystal  info.
```sh
sh-5.1$ crystal -v
Crystal 1.6.0 [41573fadb] (2022-10-06)

LLVM: 13.0.1
Default target: x86_64-unknown-linux-gnu
```
New [enum](https://github.com/crystal-ameba/ameba/pull/277/files) which was added in 1.2 I can't compile.

```
╰─$ crystal a.cr --error-trace
Showing last frame. Use --error-trace for full trace.

In a.cr:1:3

 1 | p Crystal::Keyword::BEGIN
       ^----------------------
Error: undefined constant Crystal::Keyword::BEGIN
```

I tred to get access to `Crystal::Keyword` but fail, old version still work.

Same issue on other project https://github.com/grokify/crystal-financialmodelingprep/issues/9

Can you merge this patch or if you have any other ideas I can update MR