### PR TITLE
Enable `Lint/EmptyExpression` by default

### DIFF
--- a/src/ameba/rule/lint/empty_expression.cr
+++ b/src/ameba/rule/lint/empty_expression.cr
@@ -31,7 +31,6 @@ module Ameba::Rule::Lint
     include AST::Util
 
     properties do
-      enabled false
       description "Disallows empty expressions"
     end
 


### PR DESCRIPTION
It was disabled in de3f16a9dcf4e995f3f242554a8d363e2d06f9dc due to the https://github.com/crystal-lang/crystal/issues/9857, which no longer applies.