### PR TITLE
Fix `Source::Corrector#remove_{leading,trailing}` methods

### DIFF
--- a/src/ameba/source/corrector.cr
+++ b/src/ameba/source/corrector.cr
@@ -57,14 +57,14 @@ class Ameba::Source
     # If *size* is greater than the size of the range, the removed region can
     # overrun the end of the range.
     def remove_leading(location, end_location, size)
-      remove(loc_to_pos(location), loc_to_pos(location) + size)
+      @rewriter.remove(loc_to_pos(location), loc_to_pos(location) + size)
     end
 
     # Removes *size* characters from the end of the given range.
     # If *size* is greater than the size of the range, the removed region can
     # overrun the beginning of the range.
     def remove_trailing(location, end_location, size)
-      remove(loc_to_pos(end_location) + 1 - size, loc_to_pos(end_location) + 1)
+      @rewriter.remove(loc_to_pos(end_location) + 1 - size, loc_to_pos(end_location) + 1)
     end
 
     private def loc_to_pos(location : Crystal::Location | {Int32, Int32})


### PR DESCRIPTION
I've noticed this bug while working on a new rule, so here goes the fix.

Before any usage would end up with error:

```cr
λ git master → shards build
Dependencies are satisfied
Building: ameba
Error target ameba failed to compile:
Showing last frame. Use --error-trace for full trace.

In src/ameba/source/corrector.cr:28:35

 28 | @rewriter.remove(loc_to_pos(location), loc_to_pos(end_location) + 1)
                                  ^-------
Error: expected argument #1 to 'Ameba::Source::Corrector#loc_to_pos' to be (Crystal::Location | Tuple(Int32, Int32)), not Int32

Overloads are:
 - Ameba::Source::Corrector#loc_to_pos(location : Crystal::Location | ::Tuple(Int32, Int32))
```