### PR TITLE
Remove trailing dots from rule descriptions

### DIFF
--- a/src/ameba/rule/lint/shadowing_outer_local_var.cr
+++ b/src/ameba/rule/lint/shadowing_outer_local_var.cr
@@ -32,8 +32,8 @@ module Ameba::Rule::Lint
   # ```
   class ShadowingOuterLocalVar < Base
     properties do
-      description "Disallows the usage of the same name as outer local variables" \
-                  " for block or proc arguments."
+      description "Disallows the usage of the same name as outer local variables " \
+                  "for block or proc arguments"
     end
 
     MSG = "Shadowing outer local variable `%s`"

--- a/src/ameba/rule/lint/shared_var_in_fiber.cr
+++ b/src/ameba/rule/lint/shared_var_in_fiber.cr
@@ -51,7 +51,7 @@ module Ameba::Rule::Lint
   # ```
   class SharedVarInFiber < Base
     properties do
-      description "Disallows shared variables in fibers."
+      description "Disallows shared variables in fibers"
     end
 
     MSG = "Shared variable `%s` is used in fiber"

--- a/src/ameba/rule/performance/any_after_filter.cr
+++ b/src/ameba/rule/performance/any_after_filter.cr
@@ -28,7 +28,7 @@ module Ameba::Rule::Performance
   # ```
   class AnyAfterFilter < Base
     properties do
-      description "Identifies usage of `any?` calls that follow filters."
+      description "Identifies usage of `any?` calls that follow filters"
       filter_names : Array(String) = %w(select reject)
     end
 

--- a/src/ameba/rule/performance/any_instead_of_empty.cr
+++ b/src/ameba/rule/performance/any_instead_of_empty.cr
@@ -31,7 +31,7 @@ module Ameba::Rule::Performance
     include AST::Util
 
     properties do
-      description "Identifies usage of arg-less `any?` calls."
+      description "Identifies usage of arg-less `any?` calls"
     end
 
     ANY_NAME = "any?"

--- a/src/ameba/rule/performance/chained_call_with_no_bang.cr
+++ b/src/ameba/rule/performance/chained_call_with_no_bang.cr
@@ -40,7 +40,7 @@ module Ameba::Rule::Performance
     include AST::Util
 
     properties do
-      description "Identifies usage of chained calls not utilizing the bang method variants."
+      description "Identifies usage of chained calls not utilizing the bang method variants"
 
       # All of those have bang method variants returning `self`
       # and are not modifying the receiver type (like `compact` does),

--- a/src/ameba/rule/performance/compact_after_map.cr
+++ b/src/ameba/rule/performance/compact_after_map.cr
@@ -23,7 +23,7 @@ module Ameba::Rule::Performance
   # ```
   class CompactAfterMap < Base
     properties do
-      description "Identifies usage of `compact` calls that follow `map`."
+      description "Identifies usage of `compact` calls that follow `map`"
     end
 
     COMPACT_NAME = "compact"

--- a/src/ameba/rule/performance/first_last_after_filter.cr
+++ b/src/ameba/rule/performance/first_last_after_filter.cr
@@ -27,7 +27,7 @@ module Ameba::Rule::Performance
   # ```
   class FirstLastAfterFilter < Base
     properties do
-      description "Identifies usage of `first/last/first?/last?` calls that follow filters."
+      description "Identifies usage of `first/last/first?/last?` calls that follow filters"
       filter_names : Array(String) = %w(select)
     end
 

--- a/src/ameba/rule/performance/flatten_after_map.cr
+++ b/src/ameba/rule/performance/flatten_after_map.cr
@@ -23,7 +23,7 @@ module Ameba::Rule::Performance
   # ```
   class FlattenAfterMap < Base
     properties do
-      description "Identifies usage of `flatten` calls that follow `map`."
+      description "Identifies usage of `flatten` calls that follow `map`"
     end
 
     FLATTEN_NAME = "flatten"

--- a/src/ameba/rule/performance/map_instead_of_block.cr
+++ b/src/ameba/rule/performance/map_instead_of_block.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Performance
   # ```
   class MapInsteadOfBlock < Base
     properties do
-      description "Identifies usage of `sum/product` calls that follow `map`."
+      description "Identifies usage of `sum/product` calls that follow `map`"
     end
 
     CALL_NAMES = %w(sum product)

--- a/src/ameba/rule/style/guard_clause.cr
+++ b/src/ameba/rule/style/guard_clause.cr
@@ -56,7 +56,7 @@ module Ameba::Rule::Style
 
     properties do
       enabled false
-      description "Check for conditionals that can be replaced with guard clauses."
+      description "Check for conditionals that can be replaced with guard clauses"
     end
 
     MSG = "Use a guard clause (`%s`) instead of wrapping the " \

--- a/src/ameba/rule/style/is_a_filter.cr
+++ b/src/ameba/rule/style/is_a_filter.cr
@@ -40,7 +40,7 @@ module Ameba::Rule::Style
   # ```
   class IsAFilter < Base
     properties do
-      description "Identifies usage of `is_a?/nil?` calls within filters."
+      description "Identifies usage of `is_a?/nil?` calls within filters"
       filter_names : Array(String) = %w(select reject any? all? none? one?)
     end
 

--- a/src/ameba/rule/style/verbose_block.cr
+++ b/src/ameba/rule/style/verbose_block.cr
@@ -31,7 +31,7 @@ module Ameba::Rule::Style
     include AST::Util
 
     properties do
-      description "Identifies usage of collapsible single expression blocks."
+      description "Identifies usage of collapsible single expression blocks"
 
       exclude_multiple_line_blocks true
       exclude_calls_with_block true


### PR DESCRIPTION
Thus, making rule descriptions uniform in that regard.