### PR TITLE
Refactor `Style/PredicateName` rule

### DIFF
--- a/spec/ameba/rule/style/predicate_name_spec.cr
+++ b/spec/ameba/rule/style/predicate_name_spec.cr
@@ -30,7 +30,7 @@ module Ameba::Rule::Style
     it "reports rule, pos and message" do
       s = Source.new %q(
         class Image
-          def has_picture?(x)
+          def is_valid?(x)
             true
           end
         end
@@ -42,7 +42,7 @@ module Ameba::Rule::Style
       issue.location.to_s.should eq "source.cr:2:3"
       issue.end_location.to_s.should eq "source.cr:4:5"
       issue.message.should eq(
-        "Favour method name 'picture?' over 'has_picture?'")
+        "Favour method name 'valid?' over 'is_valid?'")
     end
 
     it "ignores if alternative name isn't valid syntax" do

--- a/src/ameba/rule/style/predicate_name.cr
+++ b/src/ameba/rule/style/predicate_name.cr
@@ -1,24 +1,19 @@
 module Ameba::Rule::Style
-  # A rule that disallows tautological predicate names, meaning those that
-  # start with the prefix `has_` or the prefix `is_`. Ignores if the alternative isn't valid Crystal code (e.g. `is_404?`).
+  # A rule that disallows tautological predicate names -
+  # meaning those that start with the prefix `is_`, except for
+  # the ones that are not valid Crystal code (e.g. `is_404?`).
   #
-  # Favour these:
+  # Favour this:
   #
   # ```
   # def valid?(x)
   # end
-  #
-  # def picture?(x)
-  # end
   # ```
   #
-  # Over these:
+  # Over this:
   #
   # ```
   # def is_valid?(x)
-  # end
-  #
-  # def has_picture?(x)
   # end
   # ```
   #
@@ -37,9 +32,8 @@ module Ameba::Rule::Style
     MSG = "Favour method name '%s?' over '%s'"
 
     def test(source, node : Crystal::Def)
-      return unless node.name =~ /^(is|has)_(\w+)\?/
-      alternative = $2
-      return unless alternative =~ /^[a-z][a-zA-Z_0-9]*$/
+      return unless node.name =~ /^is_([a-z]\w*)\?$/
+      alternative = $1
 
       issue_for node, MSG % {alternative, node.name}
     end

--- a/src/ameba/rule/style/predicate_name.cr
+++ b/src/ameba/rule/style/predicate_name.cr
@@ -25,7 +25,6 @@ module Ameba::Rule::Style
   # ```
   class PredicateName < Base
     properties do
-      enabled false
       description "Disallows tautological predicate names"
     end
 


### PR DESCRIPTION
- Removes reporting for `has_<name>?` method names, since they're in most cases legit (`is != has`)
- Enabled by default
