### PR TITLE
Refactor rules’ default group severity handling

### DIFF
--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -255,9 +255,8 @@ class Ameba::Config
       {% end %}
 
       {% if properties["severity".id] == nil %}
-        {% default = @type.name.starts_with?("Ameba::Rule::Lint") ? "Ameba::Severity::Warning".id : "Ameba::Severity::Convention".id %}
         @[YAML::Field(key: "Severity", converter: Ameba::SeverityYamlConverter)]
-        property severity = {{ default }}
+        property severity = {{ @type }}.default_severity
       {% end %}
 
       {% if properties["excluded".id] == nil %}
@@ -267,6 +266,14 @@ class Ameba::Config
     end
 
     macro included
+      GROUP_SEVERITY = {
+        Lint: Ameba::Severity::Warning,
+      }
+
+      class_getter default_severity : Ameba::Severity do
+        GROUP_SEVERITY[group_name]? || Ameba::Severity::Convention
+      end
+
       macro inherited
         include YAML::Serializable
         include YAML::Serializable::Strict

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -267,7 +267,9 @@ class Ameba::Config
 
     macro included
       GROUP_SEVERITY = {
-        Lint: Ameba::Severity::Warning,
+        Lint:        Ameba::Severity::Warning,
+        Metrics:     Ameba::Severity::Warning,
+        Performance: Ameba::Severity::Warning,
       }
 
       class_getter default_severity : Ameba::Severity do

--- a/src/ameba/rule/layout/trailing_whitespace.cr
+++ b/src/ameba/rule/layout/trailing_whitespace.cr
@@ -9,7 +9,7 @@ module Ameba::Rule::Layout
   # ```
   class TrailingWhitespace < Base
     properties do
-      description "Disallows trailing whitespaces"
+      description "Disallows trailing whitespace"
     end
 
     MSG = "Trailing whitespace detected"

--- a/src/ameba/rule/lint/redundant_with_index.cr
+++ b/src/ameba/rule/lint/redundant_with_index.cr
@@ -2,6 +2,7 @@ module Ameba::Rule::Lint
   # A rule that disallows redundant `with_index` calls.
   #
   # For example, this is considered invalid:
+  #
   # ```
   # collection.each.with_index do |e|
   #   # ...

--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -88,8 +88,7 @@ module Ameba
       @formatter.started @sources
 
       channels = @sources.map { Channel(Exception?).new }
-      @sources.each_with_index do |source, idx|
-        channel = channels[idx]
+      @sources.zip(channels).each do |source, channel|
         spawn do
           run_source(source)
         rescue e


### PR DESCRIPTION
In addition, this PR changes default severity of `Performance` and `Metrics` groups from `convention` to `warning`.