### PR TITLE
Make `Lint/NotNilAfterNoBang` report calls to `#rindex`

### DIFF
--- a/spec/ameba/rule/lint/not_nil_after_no_bang_spec.cr
+++ b/spec/ameba/rule/lint/not_nil_after_no_bang_spec.cr
@@ -7,7 +7,9 @@ module Ameba::Rule::Lint
     it "passes for valid cases" do
       expect_no_issues subject, <<-CRYSTAL
         (1..3).index(1).not_nil!(:foo)
+        (1..3).rindex(1).not_nil!(:foo)
         (1..3).index { |i| i > 2 }.not_nil!(:foo)
+        (1..3).rindex { |i| i > 2 }.not_nil!(:foo)
         (1..3).find { |i| i > 2 }.not_nil!(:foo)
         CRYSTAL
     end
@@ -23,6 +25,17 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    it "reports if there is an `rindex` call followed by `not_nil!`" do
+      source = expect_issue subject, <<-CRYSTAL
+        (1..3).rindex(1).not_nil!
+             # ^^^^^^^^^^^^^^^^^^ error: Use `rindex! {...}` instead of `rindex {...}.not_nil!`
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        (1..3).rindex!(1)
+        CRYSTAL
+    end
+
     it "reports if there is an `index` call with block followed by `not_nil!`" do
       source = expect_issue subject, <<-CRYSTAL
         (1..3).index { |i| i > 2 }.not_nil!
@@ -31,6 +44,17 @@ module Ameba::Rule::Lint
 
       expect_correction source, <<-CRYSTAL
         (1..3).index! { |i| i > 2 }
+        CRYSTAL
+    end
+
+    it "reports if there is an `rindex` call with block followed by `not_nil!`" do
+      source = expect_issue subject, <<-CRYSTAL
+        (1..3).rindex { |i| i > 2 }.not_nil!
+             # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Use `rindex! {...}` instead of `rindex {...}.not_nil!`
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        (1..3).rindex! { |i| i > 2 }
         CRYSTAL
     end
 

--- a/src/ameba/rule/lint/not_nil_after_no_bang.cr
+++ b/src/ameba/rule/lint/not_nil_after_no_bang.cr
@@ -1,5 +1,6 @@
 module Ameba::Rule::Lint
-  # This rule is used to identify usage of `index/find` calls followed by `not_nil!`.
+  # This rule is used to identify usage of `index/rindex/find` calls
+  # followed by a call to `not_nil!`.
   #
   # For example, this is considered a code smell:
   #
@@ -23,11 +24,11 @@ module Ameba::Rule::Lint
     include AST::Util
 
     properties do
-      description "Identifies usage of `index/find` calls followed by `not_nil!`"
+      description "Identifies usage of `index/rindex/find` calls followed by `not_nil!`"
     end
 
-    BLOCK_CALL_NAMES = %w(index find)
-    CALL_NAMES       = %w(index)
+    BLOCK_CALL_NAMES = %w(index rindex find)
+    CALL_NAMES       = %w(index rindex)
 
     NOT_NIL_NAME = "not_nil!"
     MSG          = "Use `%s! {...}` instead of `%s {...}.not_nil!`"


### PR DESCRIPTION
Requires Crystal 1.7.0