### PR TITLE
Remove buggy auto-correction from `Performance/AnyInsteadOfEmpty` rule

### DIFF
--- a/spec/ameba/rule/performance/any_instead_of_empty_spec.cr
+++ b/spec/ameba/rule/performance/any_instead_of_empty_spec.cr
@@ -14,13 +14,9 @@ module Ameba::Rule::Performance
     end
 
     it "reports if there is any? call without a block nor argument" do
-      source = expect_issue subject, <<-CRYSTAL
+      expect_issue subject, <<-CRYSTAL
         [1, 2, 3].any?
                 # ^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
-        CRYSTAL
-
-      expect_correction source, <<-CRYSTAL
-        ![1, 2, 3].empty?
         CRYSTAL
     end
 
@@ -32,13 +28,9 @@ module Ameba::Rule::Performance
 
     context "macro" do
       it "reports in macro scope" do
-        source = expect_issue subject, <<-CRYSTAL
+        expect_issue subject, <<-CRYSTAL
           {{ [1, 2, 3].any? }}
                      # ^^^^ error: Use `!{...}.empty?` instead of `{...}.any?`
-          CRYSTAL
-
-        expect_correction source, <<-CRYSTAL
-          {{ ![1, 2, 3].empty? }}
           CRYSTAL
       end
     end

--- a/src/ameba/rule/performance/any_instead_of_empty.cr
+++ b/src/ameba/rule/performance/any_instead_of_empty.cr
@@ -42,14 +42,10 @@ module Ameba::Rule::Performance
       return unless node.block.nil? && node.args.empty?
       return unless node.obj
 
-      return unless location = node.location
       return unless name_location = node.name_location
       return unless end_location = name_end_location(node)
 
-      issue_for name_location, end_location, MSG do |corrector|
-        corrector.insert_before(location, '!')
-        corrector.replace(name_location, end_location, "empty?")
-      end
+      issue_for name_location, end_location, MSG
     end
   end
 end


### PR DESCRIPTION
It was failing in several hard-to-fix edge-cases, so for now I'll remove it in order to avoid producing invalid code.