### PR TITLE
Use Crystal 1.6.x for ameba v1.4

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,6 @@ scripts:
 executables:
   - ameba
 
-crystal: "~> 1.7.0"
+crystal: "~> 1.6.0"
 
 license: MIT


### PR DESCRIPTION
Ameba v1.4 is supposed to work with Crystal < 1.7.
Ameba v1.5 OTOH should support Crystal 1.7+.

This requires re-release.