### PR TITLE
Support hierarchical loading of the config file

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -21,7 +21,7 @@ module Ameba::Cli
       %w(-c --config).each do |f|
         it "accepts #{f} flag" do
           c = Cli.parse_args [f, "config.yml"]
-          c.config.should eq "config.yml"
+          c.config.should eq Path["config.yml"]
         end
       end
 
@@ -80,12 +80,6 @@ module Ameba::Cli
       it "doesn't disable colors by default" do
         c = Cli.parse_args %w(--all)
         c.colors?.should be_true
-      end
-
-      it "ignores --config if --gen-config flag passed" do
-        c = Cli.parse_args %w(--gen-config --config my_config.yml)
-        c.formatter.should eq :todo
-        c.config.should eq ""
       end
 
       describe "-e/--explain" do
@@ -166,7 +160,7 @@ module Ameba::Cli
         c.globs.should be_nil
         c.only.should be_nil
         c.except.should be_nil
-        c.config.should eq Config::PATH
+        c.config.should be_nil
       end
     end
   end

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -20,7 +20,7 @@ module Ameba
 
   describe Formatter::TODOFormatter do
     ::Spec.after_each do
-      FileUtils.rm_rf(Ameba::Config::PATH)
+      FileUtils.rm_rf(Ameba::Config::DEFAULT_PATH)
     end
 
     context "problems not found" do
@@ -45,7 +45,7 @@ module Ameba
           s = Source.new "a = 1", "source.cr"
           s.add_issue DummyRule.new, {1, 2}, "message"
           formatter.finished([s])
-          io.to_s.should contain "Created #{Config::PATH}"
+          io.to_s.should contain "Created #{Config::DEFAULT_PATH}"
         end
       end
 

--- a/spec/ameba/formatter/todo_formatter_spec.cr
+++ b/spec/ameba/formatter/todo_formatter_spec.cr
@@ -45,7 +45,7 @@ module Ameba
           s = Source.new "a = 1", "source.cr"
           s.add_issue DummyRule.new, {1, 2}, "message"
           formatter.finished([s])
-          io.to_s.should contain "Created .ameba.yml"
+          io.to_s.should contain "Created #{Config::PATH}"
         end
       end
 

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -44,7 +44,7 @@ module Ameba::Cli
   end
 
   private class Opts
-    property config = Config::PATH
+    property config : Path?
     property formatter : Symbol | String | Nil
     property globs : Array(String)?
     property only : Array(String)?
@@ -76,7 +76,7 @@ module Ameba::Cli
 
       parser.on("-c", "--config PATH",
         "Specify a configuration file") do |path|
-        opts.config = path unless opts.config.empty?
+        opts.config = Path[path] unless path.empty?
       end
 
       parser.on("-f", "--format FORMATTER",
@@ -105,7 +105,6 @@ module Ameba::Cli
       parser.on("--gen-config",
         "Generate a configuration file acting as a TODO list") do
         opts.formatter = :todo
-        opts.config = ""
       end
 
       parser.on("--fail-level SEVERITY",

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -10,8 +10,30 @@ require "./glob_utils"
 # config.formatter = my_formatter
 # ```
 #
-# By default config loads `.ameba.yml` file in a current directory.
+# By default config loads `.ameba.yml` file located in a current
+# working directory.
 #
+# If it cannot be found until reaching the root directory, then it will be
+# searched for in the user’s global config locations, which consists of a
+# dotfile or a config file inside the XDG Base Directory specification.
+#
+# - `~/.ameba.yml`
+# - `$XDG_CONFIG_HOME/ameba/config.yml` (expands to `~/.config/ameba/config.yml`
+#   if `$XDG_CONFIG_HOME` is not set)
+#
+# If both files exist, the dotfile will be selected.
+#
+# As an example, if Ameba is invoked from inside `/path/to/project/lib/utils`,
+# then it will use the config as specified inside the first of the following files:
+#
+# - `/path/to/project/lib/utils/.ameba.yml`
+# - `/path/to/project/lib/.ameba.yml`
+# - `/path/to/project/.ameba.yml`
+# - `/path/to/.ameba.yml`
+# - `/path/.ameba.yml`
+# - `/.ameba.yml`
+# - `~/.ameba.yml`
+# - `~/.config/ameba/config.yml`
 class Ameba::Config
   include GlobUtils
 

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -24,9 +24,10 @@ class Ameba::Config
     json:     Formatter::JSONFormatter,
   }
 
-  DEFAULT_PATHS = {
-    "~/.ameba.yml",
-    "~/.config/ameba/config.yml",
+  XDG_CONFIG_HOME = ENV.fetch("XDG_CONFIG_HOME", "~/.config")
+  DEFAULT_PATHS   = {
+    Path["~/.ameba.yml"],
+    Path[XDG_CONFIG_HOME] / "ameba/config.yml",
   }
   FILENAME     = ".ameba.yml"
   DEFAULT_PATH = Path[Dir.current] / FILENAME

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -114,22 +114,25 @@ class Ameba::Config
     raise "Config file is invalid: #{e.message}"
   end
 
-  protected def self.read_config(path) : String?
+  protected def self.read_config(path = nil)
     if path
       return File.exists?(path) ? File.read(path) : nil
     end
+    each_config_path do |config_path|
+      return File.read(config_path) if File.exists?(config_path)
+    end
+  end
+
+  protected def self.each_config_path(&)
     path = Path[DEFAULT_PATH].expand(home: true)
 
-    search_paths = path
-      .parents
-      .map! { |search_path| search_path / FILENAME }
-
+    search_paths = path.parents
     search_paths.reverse_each do |search_path|
-      return File.read(search_path) if File.exists?(search_path)
+      yield search_path / FILENAME
     end
 
     DEFAULT_PATHS.each do |default_path|
-      return File.read(default_path) if File.exists?(default_path)
+      yield default_path
     end
   end
 

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -28,8 +28,8 @@ class Ameba::Config
     "~/.ameba.yml",
     "~/.config/ameba/config.yml",
   }
-  FILENAME = ".ameba.yml"
-  PATH     = Path[Dir.current] / FILENAME
+  FILENAME     = ".ameba.yml"
+  DEFAULT_PATH = Path[Dir.current] / FILENAME
 
   DEFAULT_GLOBS = %w(
     **/*.cr
@@ -94,7 +94,7 @@ class Ameba::Config
     if path
       return File.exists?(path) ? File.read(path) : nil
     end
-    path = Path[PATH].expand(home: true)
+    path = Path[DEFAULT_PATH].expand(home: true)
 
     search_paths = path
       .parents

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -25,12 +25,13 @@ class Ameba::Config
   }
 
   XDG_CONFIG_HOME = ENV.fetch("XDG_CONFIG_HOME", "~/.config")
-  DEFAULT_PATHS   = {
-    Path["~/.ameba.yml"],
+
+  FILENAME      = ".ameba.yml"
+  DEFAULT_PATH  = Path[Dir.current] / FILENAME
+  DEFAULT_PATHS = {
+    Path["~"] / FILENAME,
     Path[XDG_CONFIG_HOME] / "ameba/config.yml",
   }
-  FILENAME     = ".ameba.yml"
-  DEFAULT_PATH = Path[Dir.current] / FILENAME
 
   DEFAULT_GLOBS = %w(
     **/*.cr

--- a/src/ameba/formatter/todo_formatter.cr
+++ b/src/ameba/formatter/todo_formatter.cr
@@ -26,7 +26,7 @@ module Ameba::Formatter
     end
 
     private def generate_todo_config(issues)
-      file = File.new(Config::PATH, mode: "w")
+      file = File.new(Config::DEFAULT_PATH, mode: "w")
       file << header
       rule_issues_map(issues).each do |rule, rule_issues|
         file << "\n# Problems found: #{rule_issues.size}"


### PR DESCRIPTION
Files are searched for in the same order as used by [RuboCop](https://docs.rubocop.org/rubocop/configuration.html#config-file-locations).

Resolves #275