### PR TITLE
Fix severity type for YAML converter spec

### DIFF
--- a/spec/ameba/severity_spec.cr
+++ b/spec/ameba/severity_spec.cr
@@ -45,7 +45,7 @@ module Ameba
     include YAML::Serializable
 
     @[YAML::Field(converter: Ameba::SeverityYamlConverter)]
-    property severity : Severity
+    property severity : Severity?
   end
 
   describe SeverityYamlConverter do


### PR DESCRIPTION
The return type of `SeverityYamlConverter.from_yaml` is `Severity?`, but the implementation of `YAML::Serializable` previously swallowed `Nil` values. This was recently fixed in https://github.com/crystal-lang/crystal/pull/13238, so now the compiler complains about assigning a value of type `Severity?` to an ivar typed `Severity` (https://github.com/crystal-ameba/ameba/actions/runs/4592466318/jobs/8109527429#step:5:24).

This is only a minimal fix to make the spec succeed.
But it might be a good idea to change something about that `Nil` type. I don't think it really even works to have a `Nil` severity.

