### PR TITLE
Update Dockerfile for Crystal 1.8 + check if binary works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ COPY . /ameba/
 RUN make clean && make
 
 FROM alpine:latest
-RUN apk add --update yaml pcre gc libevent libgcc
+RUN apk add --update yaml pcre2 gc libevent libgcc
 RUN mkdir /src
 WORKDIR /src
 COPY --from=builder /ameba/bin/ameba /usr/bin/
+RUN ameba -v
 ENTRYPOINT [ "/usr/bin/ameba" ]


### PR DESCRIPTION
Crystal 1.8.0+ requires pcre2.

I've also added `RUN ameba -v` to check if the binary actually works. Fixes cases like this:

```shell
$ docker run --rm -ti ameba:latest sh
Error loading shared library libpcre2-8.so.0: No such file or directory (needed by /usr/bin/ameba)
Error relocating /usr/bin/ameba: pcre2_get_ovector_count_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_config_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_get_ovector_pointer_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_match_data_create_from_pattern_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_jit_stack_assign_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_code_free_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_match_context_create_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_jit_compile_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_compile_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_get_error_message_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_jit_stack_create_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_match_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_match_data_free_8: symbol not found
Error relocating /usr/bin/ameba: pcre2_pattern_info_8: symbol not found
```