### PR TITLE
Add `Lint/Documentation` rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: shards build -Dpreview_mt
 
       - name: Run ameba linter
-        run: bin/ameba --all
+        run: bin/ameba

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 
 .PHONY: lint
 lint: build
-	./bin/ameba --all
+	./bin/ameba
 
 .PHONY: spec
 spec:

--- a/README.md
+++ b/README.md
@@ -99,15 +99,6 @@ $ ameba --explain crystal/command/format.cr:26:83 # same thing
 
 ### Run in parallel
 
-Starting from 0.31.0 Crystal [supports parallelism](https://crystal-lang.org/2019/09/06/parallelism-in-crystal.html).
-It allows to run linting in parallel too.
-In order to take advantage of this feature you need to build ameba with preview_mt support:
-
-```sh
-$ crystal build src/cli.cr -Dpreview_mt -o bin/ameba
-$ make install
-```
-
 Some quick benchmark results measured while running Ameba on Crystal repo:
 
 ```sh

--- a/spec/ameba/ast/visitors/scope_visitor_spec.cr
+++ b/spec/ameba/ast/visitors/scope_visitor_spec.cr
@@ -89,6 +89,8 @@ module Ameba::AST
           CRYSTAL
         rule.scopes.size.should eq 3
         rule.scopes.each &.visibility.should eq Crystal::Visibility::Private
+        rule.scopes.last.node.visibility.should eq Crystal::Visibility::Private
+        rule.scopes[0...-1].each &.node.visibility.should eq Crystal::Visibility::Public
       end
     end
   end

--- a/spec/ameba/rule/lint/documentation_spec.cr
+++ b/spec/ameba/rule/lint/documentation_spec.cr
@@ -1,0 +1,139 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  subject = Documentation.new
+    .tap(&.ignore_classes = false)
+    .tap(&.ignore_modules = false)
+    .tap(&.ignore_defs = false)
+
+  describe Documentation do
+    it "passes for undocumented private types" do
+      expect_no_issues subject, <<-CRYSTAL
+        private class Foo
+        end
+
+        private module Bar
+        end
+
+        private enum Baz
+        end
+
+        private def bat
+        end
+
+        private macro bag
+        end
+      CRYSTAL
+    end
+
+    it "passes for documented public types" do
+      expect_no_issues subject, <<-CRYSTAL
+        # Foo
+        class Foo
+        end
+
+        # Bar
+        module Bar
+        end
+
+        # Baz
+        enum Baz
+        end
+
+        # bat
+        def bat
+        end
+
+        # bag
+        macro bag
+        end
+      CRYSTAL
+    end
+
+    it "fails if there is an undocumented public type" do
+      expect_issue subject, <<-CRYSTAL
+        class Foo
+      # ^^^^^^^^^ error: Missing documentation
+        end
+
+        module Bar
+      # ^^^^^^^^^^ error: Missing documentation
+        end
+
+        enum Baz
+      # ^^^^^^^^ error: Missing documentation
+        end
+
+        def bat
+      # ^^^^^^^ error: Missing documentation
+        end
+
+        macro bag
+      # ^^^^^^^^^ error: Missing documentation
+        end
+      CRYSTAL
+    end
+
+    context "properties" do
+      describe "#ignore_classes" do
+        it "lets the rule to ignore method definitions if true" do
+          rule = Documentation.new
+          rule.ignore_classes = true
+
+          expect_no_issues rule, <<-CRYSTAL
+            class Foo
+            end
+            CRYSTAL
+        end
+      end
+
+      describe "#ignore_modules" do
+        it "lets the rule to ignore method definitions if true" do
+          rule = Documentation.new
+          rule.ignore_modules = true
+
+          expect_no_issues rule, <<-CRYSTAL
+            module Bar
+            end
+            CRYSTAL
+        end
+      end
+
+      describe "#ignore_enums" do
+        it "lets the rule to ignore method definitions if true" do
+          rule = Documentation.new
+          rule.ignore_enums = true
+
+          expect_no_issues rule, <<-CRYSTAL
+            enum Baz
+            end
+            CRYSTAL
+        end
+      end
+
+      describe "#ignore_defs" do
+        it "lets the rule to ignore method definitions if true" do
+          rule = Documentation.new
+          rule.ignore_defs = true
+
+          expect_no_issues rule, <<-CRYSTAL
+            def bat
+            end
+            CRYSTAL
+        end
+      end
+
+      describe "#ignore_macros" do
+        it "lets the rule to ignore macros if true" do
+          rule = Documentation.new
+          rule.ignore_macros = true
+
+          expect_no_issues rule, <<-CRYSTAL
+            macro bag
+            end
+            CRYSTAL
+        end
+      end
+    end
+  end
+end

--- a/spec/ameba/rule/lint/documentation_spec.cr
+++ b/spec/ameba/rule/lint/documentation_spec.cr
@@ -4,15 +4,21 @@ module Ameba::Rule::Lint
   subject = Documentation.new
     .tap(&.ignore_classes = false)
     .tap(&.ignore_modules = false)
+    .tap(&.ignore_enums = false)
     .tap(&.ignore_defs = false)
+    .tap(&.ignore_macros = false)
 
   describe Documentation do
     it "passes for undocumented private types" do
       expect_no_issues subject, <<-CRYSTAL
         private class Foo
+          def foo
+          end
         end
 
         private module Bar
+          def bar
+          end
         end
 
         private enum Baz
@@ -30,10 +36,16 @@ module Ameba::Rule::Lint
       expect_no_issues subject, <<-CRYSTAL
         # Foo
         class Foo
+          # foo
+          def foo
+          end
         end
 
         # Bar
         module Bar
+          # bar
+          def bar
+          end
         end
 
         # Baz

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -43,6 +43,9 @@ module Ameba
       description "Internal rule to test scopes"
     end
 
+    def test(source, node : Crystal::VisibilityModifier, scope : AST::Scope)
+    end
+
     def test(source, node : Crystal::ASTNode, scope : AST::Scope)
       @scopes << scope
     end

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -7,6 +7,9 @@ module Ameba::AST
     # Whether the scope yields.
     setter yields = false
 
+    # Scope visibility level
+    setter visibility : Crystal::Visibility?
+
     # Link to local variables
     getter variables = [] of Variable
 
@@ -170,6 +173,11 @@ module Ameba::AST
       return true if @yields
       return inner_scopes.any?(&.yields?) if check_inner_scopes
       false
+    end
+
+    # Returns visibility of the current scope (could be inherited from the outer scope).
+    def visibility
+      @visibility || outer_scope.try(&.visibility)
     end
 
     # Returns `true` if current scope is a def, `false` otherwise.

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -124,10 +124,7 @@ module Ameba::AST
     # end
     # ```
     def spawn_block?
-      return false unless node.is_a?(Crystal::Block)
-
-      call = node.as(Crystal::Block).call
-      call.try(&.name) == "spawn"
+      node.as?(Crystal::Block).try(&.call).try(&.name) == "spawn"
     end
 
     # Returns `true` if current scope sits inside a macro.
@@ -170,9 +167,7 @@ module Ameba::AST
     # Returns `true` if current scope (or any of inner scopes) yields,
     # `false` otherwise.
     def yields?(check_inner_scopes = true)
-      return true if @yields
-      return inner_scopes.any?(&.yields?) if check_inner_scopes
-      false
+      @yields || (check_inner_scopes && inner_scopes.any?(&.yields?))
     end
 
     # Returns visibility of the current scope (could be inherited from the outer scope).

--- a/src/ameba/ast/visitors/node_visitor.cr
+++ b/src/ameba/ast/visitors/node_visitor.cr
@@ -1,34 +1,6 @@
 require "./base_visitor"
 
 module Ameba::AST
-  # List of nodes to be visited by Ameba's rules.
-  NODES = {
-    Alias,
-    IsA,
-    Assign,
-    Call,
-    Block,
-    Case,
-    ClassDef,
-    ClassVar,
-    Def,
-    EnumDef,
-    ExceptionHandler,
-    Expressions,
-    HashLiteral,
-    If,
-    InstanceVar,
-    LibDef,
-    ModuleDef,
-    NilLiteral,
-    StringInterpolation,
-    Unless,
-    Var,
-    When,
-    While,
-    Until,
-  }
-
   # An AST Visitor that traverses the source and allows all nodes
   # to be inspected by rules.
   #
@@ -36,6 +8,34 @@ module Ameba::AST
   # visitor = Ameba::AST::NodeVisitor.new(rule, source)
   # ```
   class NodeVisitor < BaseVisitor
+    # List of nodes to be visited by Ameba's rules.
+    NODES = {
+      Alias,
+      IsA,
+      Assign,
+      Call,
+      Block,
+      Case,
+      ClassDef,
+      ClassVar,
+      Def,
+      EnumDef,
+      ExceptionHandler,
+      Expressions,
+      HashLiteral,
+      If,
+      InstanceVar,
+      LibDef,
+      ModuleDef,
+      NilLiteral,
+      StringInterpolation,
+      Unless,
+      Var,
+      When,
+      While,
+      Until,
+    }
+
     @skip : Array(Crystal::ASTNode.class)?
 
     def initialize(@rule, @source, skip = nil)

--- a/src/ameba/ast/visitors/node_visitor.cr
+++ b/src/ameba/ast/visitors/node_visitor.cr
@@ -43,6 +43,11 @@ module Ameba::AST
       super @rule, @source
     end
 
+    def visit(node : Crystal::VisibilityModifier)
+      node.exp.visibility = node.modifier
+      true
+    end
+
     {% for name in NODES %}
       # A visit callback for `Crystal::{{ name }}` node.
       #

--- a/src/ameba/ast/visitors/scope_visitor.cr
+++ b/src/ameba/ast/visitors/scope_visitor.cr
@@ -73,7 +73,7 @@ module Ameba::AST
 
     # :nodoc:
     def visit(node : Crystal::VisibilityModifier)
-      @visibility_modifier = node.modifier
+      @visibility_modifier = node.exp.visibility = node.modifier
       true
     end
 

--- a/src/ameba/ast/visitors/scope_visitor.cr
+++ b/src/ameba/ast/visitors/scope_visitor.cr
@@ -122,6 +122,7 @@ module Ameba::AST
       @current_assign = node.value unless node.value.nil?
     end
 
+    # :nodoc:
     def end_visit(node : Crystal::TypeDeclaration)
       return unless (var = node.var).is_a?(Crystal::Var)
 

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -240,6 +240,7 @@ class Ameba::Config
 
   # :nodoc:
   module RuleConfig
+    # Define rule properties
     macro properties(&block)
       {% definitions = [] of NamedTuple %}
       {% if block.body.is_a? Assign %}

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -112,6 +112,7 @@ module Ameba::Rule
       name.hash
     end
 
+    # Adds an issue to the *source*
     macro issue_for(*args, **kwargs, &block)
       source.add_issue(self, {{ *args }}, {{ **kwargs }}) {{ block }}
     end

--- a/src/ameba/rule/lint/documentation.cr
+++ b/src/ameba/rule/lint/documentation.cr
@@ -1,0 +1,42 @@
+module Ameba::Rule::Lint
+  # A rule that enforces documentation for public types:
+  # modules, classes, enums, methods and macros.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/Documentation:
+  #   Enabled: true
+  # ```
+  class Documentation < Base
+    properties do
+      description "Enforces public types to be documented"
+
+      ignore_classes true
+      ignore_modules true
+      ignore_enums false
+      ignore_defs true
+      ignore_macros false
+    end
+
+    MSG = "Missing documentation"
+
+    def test(source)
+      AST::ScopeVisitor.new self, source
+    end
+
+    def test(source, node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::EnumDef | Crystal::Def | Crystal::Macro, scope : AST::Scope)
+      return unless node.visibility.public?
+
+      case node
+      when Crystal::ClassDef  then return if ignore_classes?
+      when Crystal::ModuleDef then return if ignore_modules?
+      when Crystal::EnumDef   then return if ignore_enums?
+      when Crystal::Def       then return if ignore_defs?
+      when Crystal::Macro     then return if ignore_macros?
+      end
+
+      issue_for(node, MSG) unless node.doc.presence
+    end
+  end
+end


### PR DESCRIPTION
Resolves #241

Unfortunately, due to the fact one can have multiple definitions of classes and modules, it's impossible at the source-level to determine the existence of documentation (for example, it might be in another file, where the class/module is defined).

Since reopening classes is way less common, they're being checked from default, modules due to their nature are not - there's still a switch to enable checking those as well, just in case.