### PR TITLE
Make postinstall portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,5 @@ bin: build
 	mkdir -p $(SHARD_BIN)
 	cp ./bin/ameba $(SHARD_BIN)
 
-.PHONY: run_file
-run_file:
-	cp -n ./bin/ameba.cr $(SHARD_BIN) || true
-
 .PHONY: test
 test: spec lint

--- a/shard.yml
+++ b/shard.yml
@@ -10,10 +10,11 @@ targets:
 
 scripts:
   # TODO: remove pre-compiled executable in future releases
-  postinstall: make bin && make run_file
+  postinstall: make build
 
 executables:
   - ameba
+  - ameba.cr
 
 crystal: "~> 1.7.0"
 

--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ targets:
 
 scripts:
   # TODO: remove pre-compiled executable in future releases
-  postinstall: make build
+  postinstall: shards build -Dpreview_mt
 
 executables:
   - ameba


### PR DESCRIPTION
There's no need for copying the executables manually (which happens in both makefile targets `bin` and `run_file`).
Shards' `executables` takes care of that.

The makefile targets could potentially be dropped as well, I don't think there would be other uses case for those.

Using `shards build` directly instead of `make build` improves portability a lot.

The result should be identical to the previous behaviour, except that it works on more platforms (including Windows).
Only practical difference is that the executables are linked instead of copied. This could perhaps be a problem for the source file `ameba.cr`. It should be fine for the binary.

This should basically "just work" almost anywhere because `shards` is always available in the environment. No need for `make` to be available and makefile compatibility doesn't matter either.

Resolves #368
