### PR TITLE
Raise error when passed invalid file paths

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -5,7 +5,7 @@ module Ameba::Cli
   describe "Cmd" do
     describe ".run" do
       it "runs ameba" do
-        r = Cli.run %w(-f silent file.cr)
+        r = Cli.run %w(-f silent -c spec/fixtures/config.yml spec/fixtures/passing_ameba.cr)
         r.should be_nil
       end
     end
@@ -43,12 +43,12 @@ module Ameba::Cli
       end
 
       it "defaults rules? flag to false" do
-        c = Cli.parse_args %w(file.cr)
+        c = Cli.parse_args %w(spec/fixtures/passing_ameba.cr)
         c.rules?.should be_false
       end
 
       it "defaults skip_reading_config? flag to false" do
-        c = Cli.parse_args %w(file.cr)
+        c = Cli.parse_args %w(spec/fixtures/passing_ameba.cr)
         c.skip_reading_config?.should be_false
       end
 
@@ -58,7 +58,7 @@ module Ameba::Cli
       end
 
       it "defaults all? flag to false" do
-        c = Cli.parse_args %w(file.cr)
+        c = Cli.parse_args %w(spec/fixtures/passing_ameba.cr)
         c.all?.should be_false
       end
 
@@ -95,35 +95,35 @@ module Ameba::Cli
 
       describe "-e/--explain" do
         it "configures file/line/column" do
-          c = Cli.parse_args %w(--explain src/file.cr:3:5)
+          c = Cli.parse_args %w(--explain spec/fixtures/passing_ameba.cr:3:5)
 
           location_to_explain = c.location_to_explain.should_not be_nil
-          location_to_explain[:file].should eq "src/file.cr"
+          location_to_explain[:file].should eq "spec/fixtures/passing_ameba.cr"
           location_to_explain[:line].should eq 3
           location_to_explain[:column].should eq 5
         end
 
         it "raises an error if location is not valid" do
           expect_raises(Exception, "location should have PATH:line:column") do
-            Cli.parse_args %w(--explain src/file.cr:3)
+            Cli.parse_args %w(--explain spec/fixtures/passing_ameba.cr:3)
           end
         end
 
         it "raises an error if line number is not valid" do
           expect_raises(Exception, "location should have PATH:line:column") do
-            Cli.parse_args %w(--explain src/file.cr:a:3)
+            Cli.parse_args %w(--explain spec/fixtures/passing_ameba.cr:a:3)
           end
         end
 
         it "raises an error if column number is not valid" do
           expect_raises(Exception, "location should have PATH:line:column") do
-            Cli.parse_args %w(--explain src/file.cr:3:&)
+            Cli.parse_args %w(--explain spec/fixtures/passing_ameba.cr:3:&)
           end
         end
 
         it "raises an error if line/column are missing" do
           expect_raises(Exception, "location should have PATH:line:column") do
-            Cli.parse_args %w(--explain src/file.cr)
+            Cli.parse_args %w(--explain spec/fixtures/passing_ameba.cr)
           end
         end
       end

--- a/spec/ameba/glob_utils_spec.cr
+++ b/spec/ameba/glob_utils_spec.cr
@@ -45,6 +45,12 @@ module Ameba
         subject.expand(["**/#{current_file_basename}", "**/#{current_file_basename}"])
           .should eq [current_file_path]
       end
+
+      it "raises an ArgumentError when the glob doesn't match any files" do
+        expect_raises(ArgumentError, "No files found matching foo/*") do
+          subject.expand(["foo/*"])
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -1,0 +1,4 @@
+Ameba/PerfRule:
+  Enabled: false
+Ameba/ErrorRule:
+  Enabled: false

--- a/src/ameba/glob_utils.cr
+++ b/src/ameba/glob_utils.cr
@@ -21,6 +21,8 @@ module Ameba
     # ```
     def expand(globs)
       globs.flat_map do |glob|
+        raise ArgumentError.new("No files found matching #{glob}") if Dir[glob].empty?
+
         glob += "/**/*.cr" if File.directory?(glob)
         Dir[glob]
       end.uniq!


### PR DESCRIPTION
#388 

See [comment](https://github.com/crystal-ameba/ameba/issues/388#issuecomment-1651562708) on #388 for my thought process. 

- I had to change `spec/ameba/cli/cmd_spec.cr` to use real files to prevent the error being thrown there.
  - This also involved changing [line 8](https://github.com/crystal-ameba/ameba/compare/master...stufro:388-raise-on-invalid-file-path?expand=1#diff-94ee7d95bcd546992514ff5718c32bf9b79b665e04feb4c75234b199cb524e8dR8) of that spec to use a config file which disables some rules defined in `spec/spec_helper.cr` which always adds errors.