### PR TITLE
Make `Lint/NotNilAfterNoBang` report calls to `#match`

### DIFF
--- a/spec/ameba/rule/lint/not_nil_after_no_bang_spec.cr
+++ b/spec/ameba/rule/lint/not_nil_after_no_bang_spec.cr
@@ -11,6 +11,7 @@ module Ameba::Rule::Lint
         (1..3).index { |i| i > 2 }.not_nil!(:foo)
         (1..3).rindex { |i| i > 2 }.not_nil!(:foo)
         (1..3).find { |i| i > 2 }.not_nil!(:foo)
+        /(.)(.)(.)/.match("abc", &.itself).not_nil!
         CRYSTAL
     end
 
@@ -33,6 +34,17 @@ module Ameba::Rule::Lint
 
       expect_correction source, <<-CRYSTAL
         (1..3).rindex!(1)
+        CRYSTAL
+    end
+
+    it "reports if there is an `match` call followed by `not_nil!`" do
+      source = expect_issue subject, <<-CRYSTAL
+        /(.)(.)(.)/.match("abc").not_nil![2]
+                  # ^^^^^^^^^^^^^^^^^^^^^ error: Use `match! {...}` instead of `match {...}.not_nil!`
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        /(.)(.)(.)/.match!("abc")[2]
         CRYSTAL
     end
 

--- a/src/ameba/rule/lint/not_nil_after_no_bang.cr
+++ b/src/ameba/rule/lint/not_nil_after_no_bang.cr
@@ -1,17 +1,17 @@
 module Ameba::Rule::Lint
-  # This rule is used to identify usage of `index/rindex/find` calls
+  # This rule is used to identify usage of `index/rindex/find/match` calls
   # followed by a call to `not_nil!`.
   #
   # For example, this is considered a code smell:
   #
   # ```
-  # %w[Alice Bob].find(&.match(/^A./)).not_nil!
+  # %w[Alice Bob].find(&.chars.any?(&.in?('o', 'b'))).not_nil!
   # ```
   #
   # And can be written as this:
   #
   # ```
-  # %w[Alice Bob].find!(&.match(/^A./))
+  # %w[Alice Bob].find!(&.chars.any?(&.in?('o', 'b')))
   # ```
   #
   # YAML configuration example:
@@ -24,11 +24,11 @@ module Ameba::Rule::Lint
     include AST::Util
 
     properties do
-      description "Identifies usage of `index/rindex/find` calls followed by `not_nil!`"
+      description "Identifies usage of `index/rindex/find/match` calls followed by `not_nil!`"
     end
 
     BLOCK_CALL_NAMES = %w(index rindex find)
-    CALL_NAMES       = %w(index rindex)
+    CALL_NAMES       = %w(index rindex match)
 
     MSG = "Use `%s! {...}` instead of `%s {...}.not_nil!`"
 


### PR DESCRIPTION
Requires Crystal 1.9.0