### PR TITLE
Revert "Fix `Performance/ExcessiveAllocations` to exclude `each` call…

### DIFF
--- a/spec/ameba/rule/performance/excessive_allocations_spec.cr
+++ b/spec/ameba/rule/performance/excessive_allocations_spec.cr
@@ -6,7 +6,6 @@ module Ameba::Rule::Performance
   describe ExcessiveAllocations do
     it "passes if there is no potential performance improvements" do
       expect_no_issues subject, <<-CRYSTAL
-        "Alice".chars.each
         "Alice".chars.each(arg) { |c| puts c }
         "Alice".chars(arg).each { |c| puts c }
         "Alice\nBob".lines.each(arg) { |l| puts l }

--- a/src/ameba/rule/performance/excessive_allocations.cr
+++ b/src/ameba/rule/performance/excessive_allocations.cr
@@ -52,7 +52,7 @@ module Ameba::Rule::Performance
     end
 
     def test(source, node : Crystal::Call)
-      return unless node.name == "each" && node.args.empty? && node.block
+      return unless node.name == "each" && node.args.empty?
       return unless (obj = node.obj).is_a?(Crystal::Call)
       return unless obj.args.empty? && obj.block.nil?
       return unless method = call_names[obj.name]?


### PR DESCRIPTION
…s without a block"

This reverts commit 29e29b8e1d04b9126fb692e2da930a6536d3bceb.

---

This change turned out to be incorrect.