### PR TITLE
Make `RuleConfig#properties` accept only `Call` nodes

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,7 +6,7 @@ module Ameba
   # Dummy Rule which does nothing.
   class DummyRule < Rule::Base
     properties do
-      description : String = "Dummy rule that does nothing."
+      description "Dummy rule that does nothing."
       dummy true
     end
 
@@ -92,7 +92,7 @@ module Ameba
 
   class PerfRule < Rule::Performance::Base
     properties do
-      description : String = "Sample performance rule"
+      description "Sample performance rule"
     end
 
     def test(source)

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -247,20 +247,20 @@ class Ameba::Config
     # Define rule properties
     macro properties(&block)
       {% definitions = [] of NamedTuple %}
-      {% if block.body.is_a? Assign %}
-        {% definitions << {var: block.body.target, value: block.body.value} %}
-      {% elsif block.body.is_a? Call %}
-        {% definitions << {var: block.body.name, value: block.body.args.first} %}
-      {% elsif block.body.is_a? TypeDeclaration %}
-        {% definitions << {var: block.body.var, value: block.body.value, type: block.body.type} %}
+      {% if (prop = block.body).is_a? Call %}
+        {% if (named_args = prop.named_args) && (type = named_args.select(&.name.== "as".id).first) %}
+          {% definitions << {var: prop.name, value: prop.args.first, type: type.value} %}
+        {% else %}
+          {% definitions << {var: prop.name, value: prop.args.first} %}
+        {% end %}
       {% elsif block.body.is_a? Expressions %}
         {% for prop in block.body.expressions %}
-          {% if prop.is_a? Assign %}
-            {% definitions << {var: prop.target, value: prop.value} %}
-          {% elsif prop.is_a? Call %}
-            {% definitions << {var: prop.name, value: prop.args.first} %}
-          {% elsif prop.is_a? TypeDeclaration %}
-            {% definitions << {var: prop.var, value: prop.value, type: prop.type} %}
+          {% if prop.is_a? Call %}
+            {% if (named_args = prop.named_args) && (type = named_args.select(&.name.== "as".id).first) %}
+              {% definitions << {var: prop.name, value: prop.args.first, type: type.value} %}
+            {% else %}
+              {% definitions << {var: prop.name, value: prop.args.first} %}
+            {% end %}
           {% end %}
         {% end %}
       {% end %}

--- a/src/ameba/rule/lint/typos.cr
+++ b/src/ameba/rule/lint/typos.cr
@@ -15,7 +15,8 @@ module Ameba::Rule::Lint
   class Typos < Base
     properties do
       description "Reports typos found in source files"
-      bin_path : String? = nil
+
+      bin_path nil, as: String?
       fail_on_error false
     end
 

--- a/src/ameba/rule/style/verbose_block.cr
+++ b/src/ameba/rule/style/verbose_block.cr
@@ -39,8 +39,8 @@ module Ameba::Rule::Style
       exclude_operators true
       exclude_setters false
 
-      max_line_length : Int32? = nil # 100
-      max_length : Int32? = 50
+      max_line_length nil, as: Int32?
+      max_length 50, as: Int32?
     end
 
     MSG          = "Use short block notation instead: `%s`"


### PR DESCRIPTION
This PR removes the support for other ways of defining properties than using a call syntax - i.e. assign and type declaration.

It also adds an optional named argument `as`, in order to specify the property type when needed (e.g. for nil-able properties).

With this change there's no need for `# ameba:disable Lint/UselessAssign` pragmas in #430.