### PR TITLE
Revert to `nil` in `Rule::Lint::Typos.BIN_PATH` if `Process.find_executable` fails

### DIFF
--- a/src/ameba/rule/lint/typos.cr
+++ b/src/ameba/rule/lint/typos.cr
@@ -22,7 +22,7 @@ module Ameba::Rule::Lint
 
     MSG = "Typo found: %s -> %s"
 
-    BIN_PATH = Process.find_executable("typos")
+    BIN_PATH = Process.find_executable("typos") rescue nil
 
     def bin_path : String?
       @bin_path || BIN_PATH


### PR DESCRIPTION
Resolves #464