### PR TITLE
Fix trailing space in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ all:
 
 BUILD_TARGET := bin/ameba
 
-DESTDIR ?=           ## Install destination dir
-PREFIX ?= /usr/local ## Install path prefix
+DESTDIR ?=          ## Install destination dir
+PREFIX ?= /usr/local## Install path prefix
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 
 # The crystal command to use


### PR DESCRIPTION
Unfortunately, GNU make does not chop off trailing whitespace from string values in assignments. So the default BINDIR was `/usr/local /bin` without this patch.

Fixes https://github.com/crystal-ameba/ameba/pull/479#discussion_r1796544960