### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/src/ameba/ast/variabling/argument.cr
+++ b/src/ameba/ast/variabling/argument.cr
@@ -9,7 +9,7 @@ module Ameba::AST
   #   3.times do |i|
   #   end
   #
-  #   ->(x : Int32) {}
+  #   ->(x : Int32) { }
   # end
   # ```
   class Argument


### PR DESCRIPTION
This fixes the CI failure on Crystal nightly due to formatter updates.