### PR TITLE
Handle empty configuration as no configuration

### DIFF
--- a/spec/ameba/config_spec.cr
+++ b/spec/ameba/config_spec.cr
@@ -15,6 +15,15 @@ module Ameba
         config.globs.should eq Config::DEFAULT_GLOBS
       end
 
+      it "loads default globs when config is empty" do
+        yml = YAML.parse <<-CONFIG
+          # Empty config with comment
+
+        CONFIG
+        config = Config.new(yml)
+        config.globs.should eq Config::DEFAULT_GLOBS
+      end
+
       it "initializes globs as string" do
         yml = YAML.parse <<-CONFIG
           ---

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -95,6 +95,9 @@ class Ameba::Config
   #
   # `Config.load` uses this constructor to instantiate new config by YAML file.
   protected def initialize(config : YAML::Any)
+    if config.raw.nil?
+      config = YAML.parse("{}")
+    end
     @rules = Rule.rules.map &.new(config).as(Rule::Base)
     @rule_groups = @rules.group_by &.group
     @excluded = load_array_section(config, "Excluded")


### PR DESCRIPTION
Crystal YAML expects a `Hash` and `Array` to perform basic operations. When no rules are defined, `ameba` currently returns the following error:

```
Error: Unable to load config file: Expected Array or Hash, not Nil`
```

This commit treats an empty configuration as if no configuration exists, preventing the error and allowing for default behavior when no rules are specified.

## References

* [YAML::Any#\[\]](https://github.com/crystal-lang/crystal/blob/dacd97bccc80b41c7d6c448cfad19d37184766e9/src/yaml/any.cr#L99)
* [YAML::Any#size](https://github.com/crystal-lang/crystal/blob/dacd97bccc80b41c7d6c448cfad19d37184766e9/src/yaml/any.cr#L84)