### PR TITLE
While passing file through `STDIN` we should lint just that

### DIFF
--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -164,14 +164,12 @@ class Ameba::Config
   # config.sources # => list of sources pointing to files found by the wildcards
   # ```
   def sources
-    srcs = (find_files_by_globs(globs) - find_files_by_globs(excluded))
-      .map { |path| Source.new File.read(path), path }
-
     if file = stdin_filename
-      srcs << Source.new(STDIN.gets_to_end, file)
+      [Source.new(STDIN.gets_to_end, file)]
+    else
+      (find_files_by_globs(globs) - find_files_by_globs(excluded))
+        .map { |path| Source.new File.read(path), path }
     end
-
-    srcs
   end
 
   # Returns a formatter to be used while inspecting files.


### PR DESCRIPTION
Fixes the flawed feature implementation from #466
Essentially reverts f29cffa83b7efc3437419ecac9a6a5c83af4e39a