### PR TITLE
Disable autocorrection when source is passed through `STDIN`

### DIFF
--- a/spec/ameba/cli/cmd_spec.cr
+++ b/spec/ameba/cli/cmd_spec.cr
@@ -32,6 +32,11 @@ module Ameba::Cli
         end
       end
 
+      it "accepts --stdin-filename flag" do
+        c = Cli.parse_args %w[--stdin-filename foo.cr]
+        c.stdin_filename.should eq "foo.cr"
+      end
+
       it "accepts --only flag" do
         c = Cli.parse_args ["--only", "RULE1,RULE2"]
         c.only.should eq %w[RULE1 RULE2]

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -5,6 +5,7 @@ require "option_parser"
 module Ameba::Cli
   extend self
 
+  # ameba:disable Metrics/CyclomaticComplexity
   def run(args = ARGV) : Nil
     opts = parse_args args
     location_to_explain = opts.location_to_explain

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -8,15 +8,20 @@ module Ameba::Cli
   def run(args = ARGV) : Nil
     opts = parse_args args
     location_to_explain = opts.location_to_explain
+    stdin_filename = opts.stdin_filename
     autocorrect = opts.autocorrect?
 
     if location_to_explain && autocorrect
       raise "Invalid usage: Cannot explain an issue and autocorrect at the same time."
     end
 
+    if stdin_filename && autocorrect
+      raise "Invalid usage: Cannot autocorrect from stdin."
+    end
+
     config = Config.load opts.config, opts.colors?, opts.skip_reading_config?
     config.autocorrect = autocorrect
-    config.stdin_filename = opts.stdin_filename
+    config.stdin_filename = stdin_filename
 
     if globs = opts.globs
       config.globs = globs


### PR DESCRIPTION
This might change when/if #504 is implemented, yet for now that's fine.