### PR TITLE
Add several rules regarding type restrictions

### DIFF
--- a/spec/ameba/base_spec.cr
+++ b/spec/ameba/base_spec.cr
@@ -19,6 +19,7 @@ module Ameba::Rule
           Naming
           Performance
           Style
+          Typing
         ]
       end
     end

--- a/spec/ameba/rule/typing/macro_call_var_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/macro_call_var_type_restriction_spec.cr
@@ -1,0 +1,42 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Typing
+  subject = MacroCallVarTypeRestriction.new
+
+  it "passes if macro call args have type restrictions" do
+    expect_no_issues subject, <<-CRYSTAL
+      class Greeter
+        getter name : String?
+        class_getter age : Int32 = 0
+        setter tasks : Array(String) = [] of String
+        class_setter queue : Array(Int32)?
+        property task_mutex : Mutex = Mutex.new
+        class_property asdf : String
+
+        record Task,
+          var1 : String,
+          var2 : String = "asdf"
+      end
+      CRYSTAL
+  end
+
+  it "fails if a macro call arg doesn't have a type restriction" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        getter name
+             # ^^^^ error: Variable arguments to `getter` require a type restriction
+      end
+      CRYSTAL
+  end
+
+  it "fails if a record call arg doesn't have a type restriction" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        record Task,
+          var1 : String,
+          var2 = "asdf"
+        # ^^^^ error: Variable arguments to `record` require a type restriction
+      end
+      CRYSTAL
+  end
+end

--- a/spec/ameba/rule/typing/macro_call_var_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/macro_call_var_type_restriction_spec.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       class Greeter
         getter name
-             # ^^^^ error: Variable arguments to `getter` require a type restriction
+             # ^^^^ error: Variable arguments to `getter` should have a type restriction
       end
       CRYSTAL
   end
@@ -35,8 +35,17 @@ module Ameba::Rule::Typing
         record Task,
           var1 : String,
           var2 = "asdf"
-        # ^^^^ error: Variable arguments to `record` require a type restriction
+        # ^^^^ error: Variable arguments to `record` should have a type restriction
       end
+      CRYSTAL
+  end
+
+  it "fails if a top-level record call arg doesn't have a type restriction" do
+    expect_issue subject, <<-CRYSTAL
+      record Task,
+        var1 : String,
+        var2 = "asdf"
+      # ^^^^ error: Variable arguments to `record` should have a type restriction
       CRYSTAL
   end
 end

--- a/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
@@ -18,7 +18,7 @@ module Ameba::Rule::Typing
   it "fails if a method param doesn't have a type" do
     expect_issue subject, <<-CRYSTAL
       def hello(a)
-              # ^ error: Method parameters require a type restriction
+              # ^ error: Method parameters should have a type restriction
         "hello world" + a
       end
       CRYSTAL
@@ -28,7 +28,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       class Greeter
         private def hello(a)
-                        # ^ error: Method parameters require a type restriction
+                        # ^ error: Method parameters should have a type restriction
           "hello world" + a
         end
       end
@@ -39,7 +39,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       class Greeter
         protected def hello(a)
-                          # ^ error: Method parameters require a type restriction
+                          # ^ error: Method parameters should have a type restriction
           "hello world" + a
         end
       end
@@ -50,7 +50,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       # This is documentation about `hello`
       def hello(a)
-              # ^ error: Method parameters require a type restriction
+              # ^ error: Method parameters should have a type restriction
         "hello world" + a
       end
       CRYSTAL
@@ -59,7 +59,7 @@ module Ameba::Rule::Typing
   it "fails if a method param with a default value doesn't have a type" do
     expect_issue subject, <<-CRYSTAL
       def hello(a = "jim")
-              # ^ error: Method parameters require a type restriction
+              # ^ error: Method parameters should have a type restriction
         "hello there, " + a
       end
       CRYSTAL

--- a/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
@@ -1,0 +1,76 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Typing
+  subject = MethodParamTypeRestriction.new
+
+  it "passes if a method param has a type" do
+    expect_no_issues subject, <<-CRYSTAL
+      def hello(a : String) : String
+        "hello world" + a
+      end
+      CRYSTAL
+  end
+
+  it "fails if a method param doesn't have a type" do
+    expect_issue subject, <<-CRYSTAL
+      def hello(a)
+              # ^ error: Method parameters require a type restriction
+        "hello world" + a
+      end
+      CRYSTAL
+  end
+
+  it "fails if a private method method param doesn't have a type" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        private def hello(a)
+                        # ^ error: Method parameters require a type restriction
+          "hello world" + a
+        end
+      end
+      CRYSTAL
+  end
+
+  it "fails if a protected method doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        protected def hello(a)
+                          # ^ error: Method parameters require a type restriction
+          "hello world" + a
+        end
+      end
+      CRYSTAL
+  end
+
+  context "properties" do
+    context "#private_methods" do
+      it "allows relaxing restriction requirement for private methods" do
+        rule = MethodParamTypeRestriction.new
+        rule.private_methods = false
+
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            private def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+    end
+
+    context "#protected_methods" do
+      it "allows relaxing restriction requirement for protected methods" do
+        rule = MethodParamTypeRestriction.new
+        rule.protected_methods = false
+
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            protected def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+    end
+  end
+end

--- a/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_param_type_restriction_spec.cr
@@ -2,6 +2,9 @@ require "../../../spec_helper"
 
 module Ameba::Rule::Typing
   subject = MethodParamTypeRestriction.new
+  subject.private_methods = true
+  subject.protected_methods = true
+  subject.undocumented = true
 
   it "passes if a method param has a type" do
     expect_no_issues subject, <<-CRYSTAL
@@ -31,7 +34,7 @@ module Ameba::Rule::Typing
       CRYSTAL
   end
 
-  it "fails if a protected method doesn't have a return type" do
+  it "fails if a protected method param doesn't have a type" do
     expect_issue subject, <<-CRYSTAL
       class Greeter
         protected def hello(a)
@@ -68,6 +71,42 @@ module Ameba::Rule::Typing
             protected def hello
               "hello world"
             end
+          end
+          CRYSTAL
+      end
+    end
+
+    context "#undocumented" do
+      rule = MethodParamTypeRestriction.new
+      rule.undocumented = false
+
+      it "allows relaxing restriction requirement for undocumented methods" do
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            def hello(a)
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+
+      it "allows relaxing restriction requirement for methods with a :nodoc: directive" do
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            # :nodoc:
+            def hello(a)
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+
+      it "fails if a documented method param doesn't have a type" do
+        expect_issue subject, <<-CRYSTAL
+          # This is documentation about `hello`
+          def hello(a)
+                  # ^ error: Method parameters require a type restriction
+            "hello world" + a
           end
           CRYSTAL
       end

--- a/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
@@ -1,0 +1,76 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Typing
+  subject = MethodReturnTypeRestriction.new
+
+  it "passes if a method has a return type" do
+    expect_no_issues subject, <<-CRYSTAL
+      def hello : String
+        "hello world"
+      end
+      CRYSTAL
+  end
+
+  it "fails if a method doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      def hello
+        # ^^^^^ error: Methods require a return type restriction
+        "hello world"
+      end
+      CRYSTAL
+  end
+
+  it "fails if a private method doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        private def hello
+                  # ^^^^^ error: Methods require a return type restriction
+          "hello world"
+        end
+      end
+      CRYSTAL
+  end
+
+  it "fails if a protected method doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      class Greeter
+        protected def hello
+                    # ^^^^^ error: Methods require a return type restriction
+          "hello world"
+        end
+      end
+      CRYSTAL
+  end
+
+  context "properties" do
+    context "#private_methods" do
+      it "allows relaxing restriction requirement for private methods" do
+        rule = MethodReturnTypeRestriction.new
+        rule.private_methods = false
+
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            private def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+    end
+
+    context "#protected_methods" do
+      it "allows relaxing restriction requirement for protected methods" do
+        rule = MethodReturnTypeRestriction.new
+        rule.protected_methods = false
+
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            protected def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+    end
+  end
+end

--- a/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
@@ -17,7 +17,7 @@ module Ameba::Rule::Typing
   it "fails if a method doesn't have a return type" do
     expect_issue subject, <<-CRYSTAL
       def hello
-        # ^^^^^ error: Methods require a return type restriction
+        # ^^^^^ error: Methods should have a return type restriction
         "hello world"
       end
       CRYSTAL
@@ -27,7 +27,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       class Greeter
         private def hello
-                  # ^^^^^ error: Methods require a return type restriction
+                  # ^^^^^ error: Methods should have a return type restriction
           "hello world"
         end
       end
@@ -38,7 +38,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       class Greeter
         protected def hello
-                    # ^^^^^ error: Methods require a return type restriction
+                    # ^^^^^ error: Methods should have a return type restriction
           "hello world"
         end
       end
@@ -49,7 +49,7 @@ module Ameba::Rule::Typing
     expect_issue subject, <<-CRYSTAL
       # This is documentation about `hello`
       def hello(a)
-        # ^^^^^ error: Methods require a return type restriction
+        # ^^^^^ error: Methods should have a return type restriction
         "hello world" + a
       end
       CRYSTAL

--- a/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
@@ -2,6 +2,9 @@ require "../../../spec_helper"
 
 module Ameba::Rule::Typing
   subject = MethodReturnTypeRestriction.new
+  subject.private_methods = true
+  subject.protected_methods = true
+  subject.undocumented = true
 
   it "passes if a method has a return type" do
     expect_no_issues subject, <<-CRYSTAL
@@ -68,6 +71,42 @@ module Ameba::Rule::Typing
             protected def hello
               "hello world"
             end
+          end
+          CRYSTAL
+      end
+    end
+
+    context "#undocumented" do
+      rule = MethodReturnTypeRestriction.new
+      rule.undocumented = false
+
+      it "allows relaxing restriction requirement for undocumented methods" do
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+
+      it "allows relaxing restriction requirement for methods with a :nodoc: directive" do
+        expect_no_issues rule, <<-CRYSTAL
+          class Greeter
+            # :nodoc:
+            def hello
+              "hello world"
+            end
+          end
+          CRYSTAL
+      end
+
+      it "fails if a documented method doesn't have a return type" do
+        expect_issue subject, <<-CRYSTAL
+          # This is documentation about `hello`
+          def hello(a)
+            # ^^^^^ error: Methods require a return type restriction
+            "hello world" + a
           end
           CRYSTAL
       end

--- a/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
@@ -45,10 +45,21 @@ module Ameba::Rule::Typing
       CRYSTAL
   end
 
+  it "fails if a documented method doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      # This is documentation about `hello`
+      def hello(a)
+        # ^^^^^ error: Methods require a return type restriction
+        "hello world" + a
+      end
+      CRYSTAL
+  end
+
   context "properties" do
     context "#private_methods" do
       it "allows relaxing restriction requirement for private methods" do
         rule = MethodReturnTypeRestriction.new
+        rule.undocumented = true
         rule.private_methods = false
 
         expect_no_issues rule, <<-CRYSTAL
@@ -64,6 +75,7 @@ module Ameba::Rule::Typing
     context "#protected_methods" do
       it "allows relaxing restriction requirement for protected methods" do
         rule = MethodReturnTypeRestriction.new
+        rule.undocumented = true
         rule.protected_methods = false
 
         expect_no_issues rule, <<-CRYSTAL
@@ -97,16 +109,6 @@ module Ameba::Rule::Typing
             def hello
               "hello world"
             end
-          end
-          CRYSTAL
-      end
-
-      it "fails if a documented method doesn't have a return type" do
-        expect_issue subject, <<-CRYSTAL
-          # This is documentation about `hello`
-          def hello(a)
-            # ^^^^^ error: Methods require a return type restriction
-            "hello world" + a
           end
           CRYSTAL
       end

--- a/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
@@ -13,7 +13,7 @@ module Ameba::Rule::Typing
   it "fails if a proc literal doesn't have a return type" do
     expect_issue subject, <<-CRYSTAL
       my_proc = ->(var : Nil) { puts var }
-              # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literals require a return type
+              # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literals should have a return type
       my_proc.call(nil)
       CRYSTAL
   end

--- a/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
@@ -1,0 +1,20 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Typing
+  subject = ProcReturnTypeRestriction.new
+
+  it "passes if a proc literal has a return type" do
+    expect_no_issues subject, <<-CRYSTAL
+      my_proc = ->(var : Nil) : Nil { puts var }
+      my_proc.call(nil)
+      CRYSTAL
+  end
+
+  it "failes if a proc literal doesn't have a return type" do
+    expect_issue subject, <<-CRYSTAL
+      my_proc = ->(var : Nil) { puts var }
+              # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literals require a return type
+      my_proc.call(nil)
+      CRYSTAL
+  end
+end

--- a/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
@@ -10,7 +10,7 @@ module Ameba::Rule::Typing
       CRYSTAL
   end
 
-  it "failes if a proc literal doesn't have a return type" do
+  it "fails if a proc literal doesn't have a return type" do
     expect_issue subject, <<-CRYSTAL
       my_proc = ->(var : Nil) { puts var }
               # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literals require a return type

--- a/src/ameba/ast/visitors/node_visitor.cr
+++ b/src/ameba/ast/visitors/node_visitor.cr
@@ -34,6 +34,7 @@ module Ameba::AST
       ModuleDef,
       MultiAssign,
       NilLiteral,
+      ProcLiteral,
       StringInterpolation,
       Unless,
       Until,

--- a/src/ameba/rule/typing/macro_call_var_type_restriction.cr
+++ b/src/ameba/rule/typing/macro_call_var_type_restriction.cr
@@ -1,0 +1,88 @@
+module Ameba::Rule::Typing
+  # A rule that enforces variable arguments to certain macros have a type restriction.
+  #
+  # For example, these are considered valid:
+  #
+  # ```
+  # class Greeter
+  #   getter name : String?
+  #   class_getter age : Int32 = 0
+  #   setter tasks : Array(String) = [] of String
+  #   class_setter queue : Array(Int32)?
+  #   property task_mutex : Mutex = Mutex.new
+  #   class_property asdf : String
+
+  #   record Task,
+  #     var1 : String,
+  #     var2 : String = "asdf"
+  # end
+  # ```
+  #
+  # And these are considered invalid:
+  #
+  # ```
+  # class Greeter
+  #   getter name
+  #
+  #   record Task,
+  #     var1 : String,
+  #     var2 = "asdf"
+  # end
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Typing/MethodParamTypeRestriction:
+  #   Enabled: true
+  #   MacroNames:
+  #    - getter
+  #    - setter
+  #    - property
+  #    - class_getter
+  #    - class_setter
+  #    - class_property
+  #    - record
+  # ```
+  class MacroCallVarTypeRestriction < Base
+    properties do
+      description "Enforces variable args to certain macros have type restrictions"
+      enabled false
+      macro_names %w(
+        getter getter? getter! class_getter class_getter? class_getter!
+        setter setter? setter! class_setter class_setter? class_setter!
+        property property? property! class_property class_property? class_property!
+        record
+      )
+    end
+
+    MSG = "Variable arguments to `%s` require a type restriction"
+
+    def test(source, node : Crystal::ClassDef | Crystal::ModuleDef)
+      each_call_node(node) do |exp|
+        return unless exp.name.in?(macro_names)
+
+        exp.args.each do |arg|
+          case arg
+          when Crystal::Assign
+            issue_for arg.target, MSG % {exp.name}, prefer_name_location: true
+          when Crystal::Path, Crystal::TypeDeclaration # Allowed
+          else
+            issue_for arg, MSG % {exp.name}, prefer_name_location: true
+          end
+        end
+      end
+    end
+
+    private def each_call_node(node, &)
+      case body = node.body
+      when Crystal::Call
+        yield body
+      when Crystal::Expressions
+        body.expressions.each do |exp|
+          yield exp if exp.is_a?(Crystal::Call)
+        end
+      end
+    end
+  end
+end

--- a/src/ameba/rule/typing/macro_call_var_type_restriction.cr
+++ b/src/ameba/rule/typing/macro_call_var_type_restriction.cr
@@ -46,7 +46,7 @@ module Ameba::Rule::Typing
   # ```
   class MacroCallVarTypeRestriction < Base
     properties do
-      description "Enforces variable args to certain macros have type restrictions"
+      description "Recommends that variable args to certain macros have type restrictions"
       enabled false
       macro_names %w(
         getter getter? getter! class_getter class_getter? class_getter!
@@ -56,31 +56,18 @@ module Ameba::Rule::Typing
       )
     end
 
-    MSG = "Variable arguments to `%s` require a type restriction"
+    MSG = "Variable arguments to `%s` should have a type restriction"
 
-    def test(source, node : Crystal::ClassDef | Crystal::ModuleDef)
-      each_call_node(node) do |exp|
-        return unless exp.name.in?(macro_names)
+    def test(source, node : Crystal::Call)
+      return unless node.name.in?(macro_names)
 
-        exp.args.each do |arg|
-          case arg
-          when Crystal::Assign
-            issue_for arg.target, MSG % {exp.name}, prefer_name_location: true
-          when Crystal::Path, Crystal::TypeDeclaration # Allowed
-          else
-            issue_for arg, MSG % {exp.name}, prefer_name_location: true
-          end
-        end
-      end
-    end
-
-    private def each_call_node(node, &)
-      case body = node.body
-      when Crystal::Call
-        yield body
-      when Crystal::Expressions
-        body.expressions.each do |exp|
-          yield exp if exp.is_a?(Crystal::Call)
+      node.args.each do |arg|
+        case arg
+        when Crystal::Assign
+          issue_for arg.target, MSG % {node.name}, prefer_name_location: true
+        when Crystal::Path, Crystal::TypeDeclaration # Allowed
+        else
+          issue_for arg, MSG % {node.name}, prefer_name_location: true
         end
       end
     end

--- a/src/ameba/rule/typing/macro_call_var_type_restriction.cr
+++ b/src/ameba/rule/typing/macro_call_var_type_restriction.cr
@@ -34,14 +34,26 @@ module Ameba::Rule::Typing
   #
   # ```
   # Typing/MethodParamTypeRestriction:
-  #   Enabled: true
+  #   Enabled: false
   #   MacroNames:
   #    - getter
-  #    - setter
-  #    - property
+  #    - getter?
+  #    - getter!
   #    - class_getter
+  #    - class_getter?
+  #    - class_getter!
+  #    - setter
+  #    - setter?
+  #    - setter!
   #    - class_setter
+  #    - class_setter?
+  #    - class_setter!
+  #    - property
+  #    - property?
+  #    - property!
   #    - class_property
+  #    - class_property?
+  #    - class_property!
   #    - record
   # ```
   class MacroCallVarTypeRestriction < Base

--- a/src/ameba/rule/typing/method_param_type_restriction.cr
+++ b/src/ameba/rule/typing/method_param_type_restriction.cr
@@ -63,7 +63,7 @@ module Ameba::Rule::Typing
   # ```
   class MethodParamTypeRestriction < Base
     properties do
-      description "Enforce method parameters have type restrictions"
+      description "Recommends that method parameters have type restrictions"
       enabled false
       default_value false
       undocumented false
@@ -72,7 +72,7 @@ module Ameba::Rule::Typing
       block_param false
     end
 
-    MSG = "Method parameters require a type restriction"
+    MSG = "Method parameters should have a type restriction"
 
     def test(source, node : Crystal::Def)
       return if check_config(node)

--- a/src/ameba/rule/typing/method_param_type_restriction.cr
+++ b/src/ameba/rule/typing/method_param_type_restriction.cr
@@ -1,0 +1,88 @@
+module Ameba::Rule::Typing
+  # A rule that enforces method parameters have type restrictions, with optional enforcement of block parameters
+  #
+  # For example, these are considered valid:
+  #
+  # ```
+  # def listen(a : String, b : String) : String
+  #   a + b
+  # end
+  #
+  # def hello(name : String?)
+  #   puts "Hello, " + (name || "there") + "!"
+  # end
+  # ```
+  #
+  # And these are considered invalid:
+  #
+  # ```
+  # def listen(a, b) : String
+  #   a + b
+  # end
+  #
+  # def hello(name)
+  #   puts "Hello, " + (name || "there") + "!"
+  # end
+  # ```
+  #
+  # When the config options `PrivateMethods` and `ProtectedMethods`
+  # are true, this rule is also applied to private and protected methods, respectively.
+  #
+  # The `BlockParam` configuration option will extend this to block params, where this is valid:
+  #
+  # ```
+  # def exec(&block : String -> String)
+  #   yield "cmd"
+  # end
+  # ```
+  #
+  # And these are invalid:
+  #
+  # ```
+  # def exec(&)
+  # end
+  #
+  # def exec(&block)
+  # end
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Typing/MethodParamTypeRestriction:
+  #   Enabled: true
+  #   PrivateMethods: true
+  #   ProtectedMethods: true
+  #   BlockParam: false
+  # ```
+  class MethodParamTypeRestriction < Base
+    properties do
+      description "Enforce method parameters have type restrictions"
+      enabled false
+      private_methods true
+      protected_methods true
+      block_param false
+    end
+
+    MSG = "Method parameters require a type restriction"
+
+    def test(source, node : Crystal::Def)
+      return if (!private_methods? && node.visibility.private?) ||
+                (!protected_methods? && node.visibility.protected?)
+
+      node.args.each do |arg|
+        next if arg.restriction
+
+        issue_for arg, MSG, prefer_name_location: true
+      end
+
+      if block_param?
+        node.block_arg.try do |block_arg|
+          next if block_arg.restriction
+
+          issue_for block_arg, MSG, prefer_name_location: true
+        end
+      end
+    end
+  end
+end

--- a/src/ameba/rule/typing/method_param_type_restriction.cr
+++ b/src/ameba/rule/typing/method_param_type_restriction.cr
@@ -48,11 +48,14 @@ module Ameba::Rule::Typing
   #
   # The config option `Undocumented` controls whether this rule applies to undocumented methods and methods with a `:nodoc:` directive.
   #
+  # The config option `DefaultValue` controls whether this rule applies to parameters that have a default value.
+  #
   # YAML configuration example:
   #
   # ```
   # Typing/MethodParamTypeRestriction:
   #   Enabled: true
+  #   DefaultValue: true
   #   Undocumented: true
   #   PrivateMethods: true
   #   ProtectedMethods: true
@@ -62,6 +65,7 @@ module Ameba::Rule::Typing
     properties do
       description "Enforce method parameters have type restrictions"
       enabled false
+      default_value false
       undocumented false
       private_methods false
       protected_methods false
@@ -74,7 +78,7 @@ module Ameba::Rule::Typing
       return if check_config(node)
 
       node.args.each do |arg|
-        next if arg.restriction
+        next if arg.restriction || (!default_value? && arg.default_value)
 
         issue_for arg, MSG, prefer_name_location: true
       end

--- a/src/ameba/rule/typing/method_param_type_restriction.cr
+++ b/src/ameba/rule/typing/method_param_type_restriction.cr
@@ -54,11 +54,11 @@ module Ameba::Rule::Typing
   #
   # ```
   # Typing/MethodParamTypeRestriction:
-  #   Enabled: true
-  #   DefaultValue: true
-  #   Undocumented: true
-  #   PrivateMethods: true
-  #   ProtectedMethods: true
+  #   Enabled: false
+  #   DefaultValue: false
+  #   Undocumented: false
+  #   PrivateMethods: false
+  #   ProtectedMethods: false
   #   BlockParam: false
   # ```
   class MethodParamTypeRestriction < Base

--- a/src/ameba/rule/typing/method_return_type_restriction.cr
+++ b/src/ameba/rule/typing/method_return_type_restriction.cr
@@ -41,14 +41,14 @@ module Ameba::Rule::Typing
   # ```
   class MethodReturnTypeRestriction < Base
     properties do
-      description "Enforce methods have a return type restriction"
+      description "Recommends that methods have a return type restriction"
       enabled false
       undocumented false
       private_methods false
       protected_methods false
     end
 
-    MSG = "Methods require a return type restriction"
+    MSG = "Methods should have a return type restriction"
 
     def test(source, node : Crystal::Def)
       return if node.return_type || check_config(node)

--- a/src/ameba/rule/typing/method_return_type_restriction.cr
+++ b/src/ameba/rule/typing/method_return_type_restriction.cr
@@ -1,0 +1,57 @@
+module Ameba::Rule::Typing
+  # A rule that enforces method definitions have a return type restriction.
+  #
+  # For example, these are considered valid:
+  #
+  # ```
+  # def hello : String
+  #   "hello world"
+  # end
+  #
+  # def listen(a, b) : Int32
+  #   0
+  # end
+  # ```
+  #
+  # And these are considered invalid:
+  #
+  # ```
+  # def hello
+  #   "hello world"
+  # end
+  #
+  # def listen(a, b)
+  #   0
+  # end
+  # ```
+  #
+  # When the config options `PrivateMethods` and `ProtectedMethods`
+  # are true, this rule is also applied to private and protected methods, respectively.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Typing/MethodReturnTypeRestriction:
+  #   Enabled: true
+  #   PrivateMethods: true
+  #   ProtectedMethods: true
+  # ```
+  class MethodReturnTypeRestriction < Base
+    properties do
+      description "Enforce methods have a return type restriction"
+      enabled false
+      private_methods true
+      protected_methods true
+    end
+
+    MSG = "Methods require a return type restriction"
+
+    def test(source, node : Crystal::Def)
+      return if node.return_type ||
+                (!private_methods? && node.visibility.private?) ||
+                (!protected_methods? && node.visibility.protected?)
+
+      issue_for node, MSG, prefer_name_location: true
+    end
+  end
+end

--- a/src/ameba/rule/typing/method_return_type_restriction.cr
+++ b/src/ameba/rule/typing/method_return_type_restriction.cr
@@ -34,10 +34,10 @@ module Ameba::Rule::Typing
   #
   # ```
   # Typing/MethodReturnTypeRestriction:
-  #   Enabled: true
-  #   Undocumented: true
-  #   PrivateMethods: true
-  #   ProtectedMethods: true
+  #   Enabled: false
+  #   Undocumented: false
+  #   PrivateMethods: false
+  #   ProtectedMethods: false
   # ```
   class MethodReturnTypeRestriction < Base
     properties do

--- a/src/ameba/rule/typing/proc_return_type_restriction.cr
+++ b/src/ameba/rule/typing/proc_return_type_restriction.cr
@@ -1,4 +1,32 @@
 module Ameba::Rule::Typing
+  # A rule that enforces that Proc literals have a return type.
+  #
+  # For example, these are considered valid:
+  #
+  # ```
+  # my_proc = ->(arg : String) : String { a + "proc" }
+  # ```
+  #
+  # ```
+  # task -> : Task { Task.new("execute this command") }
+  # ```
+  #
+  # And these are invalid:
+  #
+  # ```
+  # my_proc = ->(arg : String) { a + "proc" }
+  # ```
+  #
+  # ```
+  # task -> { Task.new("execute this command") }
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Typing/ProcReturnTypeRestriction:
+  #   Enabled: true
+  # ```
   class ProcReturnTypeRestriction < Base
     properties do
       description "Disallows proc literals without return type restrictions"

--- a/src/ameba/rule/typing/proc_return_type_restriction.cr
+++ b/src/ameba/rule/typing/proc_return_type_restriction.cr
@@ -1,0 +1,15 @@
+module Ameba::Rule::Typing
+  class ProcReturnTypeRestriction < Base
+    properties do
+      description "Disallows proc literals without return type restrictions"
+    end
+
+    MSG = "Proc literals require a return type"
+
+    def test(source, node : Crystal::ProcLiteral)
+      return if node.def.return_type
+
+      issue_for node, MSG
+    end
+  end
+end

--- a/src/ameba/rule/typing/proc_return_type_restriction.cr
+++ b/src/ameba/rule/typing/proc_return_type_restriction.cr
@@ -29,10 +29,10 @@ module Ameba::Rule::Typing
   # ```
   class ProcReturnTypeRestriction < Base
     properties do
-      description "Disallows proc literals without return type restrictions"
+      description "Recommends that proc literals have a return type restriction"
     end
 
-    MSG = "Proc literals require a return type"
+    MSG = "Proc literals should have a return type"
 
     def test(source, node : Crystal::ProcLiteral)
       return if node.def.return_type


### PR DESCRIPTION
Related to #502.

- Adds `Typing/MacroCallVarTypeRestriction`
- Adds `Typing/MethodParamTypeRestriction`
- Adds `Typing/MethodReturnTypeRestriction`
- Adds `Typing/ProcReturnTypeRestriction`

Proc return type is enabled by default as it can lead to issues with passing procs to C, and proc params otherwise need to be typed. The other rules are off by default, and have several configuration options for those who want to use them in different ways (for instance, I can see the stdlib / library shards using the method param / return type rules for public / documented methods, to ensure there isn't breakage when changes are made).

I can add the `since_version` configs once a review is done.