### PR TITLE
Fix edge cases with `Lint/UnusedComparison` and `Lint/UnusedLiteral`

### DIFF
--- a/spec/ameba/rule/lint/unused_comparison_spec.cr
+++ b/spec/ameba/rule/lint/unused_comparison_spec.cr
@@ -40,7 +40,7 @@ module Ameba::Rule::Lint
     it "passes for unused comparisons with `===`, `=~`, and `!~`" do
       expect_no_issues subject, <<-CRYSTAL
         /foo(bar)?/ =~ baz
-        "foobar" !~ /(o+)ba(r?)/
+        /foo(bar)?/ !~ baz
         "hello" === world
         CRYSTAL
     end

--- a/spec/ameba/rule/lint/unused_comparison_spec.cr
+++ b/spec/ameba/rule/lint/unused_comparison_spec.cr
@@ -30,6 +30,21 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    it "passes for comparisons inside '||' and '&&' where the other arg is a call" do
+      expect_no_issues subject, <<-CRYSTAL
+          IO.copy(in_var, out_var, len) == len || raise IO::EOFError.new
+        CRYSTAL
+    end
+
+    it "passes if a regex literal is part of a === or =~ comparison" do
+      expect_no_issues subject, <<-CRYSTAL
+        /f(o+)(bar?)/ === "fooba"
+        puts $~
+        "foobar" =~ /(o+)ba(r?)/
+        puts $1
+      CRYSTAL
+    end
+
     it "fails for all comparison operators" do
       expect_issue subject, <<-CRYSTAL
           x == 2

--- a/spec/ameba/rule/lint/unused_comparison_spec.cr
+++ b/spec/ameba/rule/lint/unused_comparison_spec.cr
@@ -37,7 +37,7 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
-    it "passes if a regex literal is part of a === or =~ comparison" do
+    it "passes if a regex literal is part of a comparison" do
       expect_no_issues subject, <<-CRYSTAL
         /f(o+)(bar?)/ === "fooba"
         puts $~

--- a/spec/ameba/rule/lint/unused_comparison_spec.cr
+++ b/spec/ameba/rule/lint/unused_comparison_spec.cr
@@ -32,7 +32,8 @@ module Ameba::Rule::Lint
 
     it "passes for comparisons inside '||' and '&&' where the other arg is a call" do
       expect_no_issues subject, <<-CRYSTAL
-          IO.copy(in_var, out_var, len) == len || raise IO::EOFError.new
+        foo(bar) == baz || raise "bat"
+        foo(bar) == baz && raise "bat"
         CRYSTAL
     end
 

--- a/spec/ameba/rule/lint/unused_comparison_spec.cr
+++ b/spec/ameba/rule/lint/unused_comparison_spec.cr
@@ -37,13 +37,12 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
-    it "passes if a regex literal is part of a comparison" do
+    it "passes for unused comparisons with `===`, `=~`, and `!~`" do
       expect_no_issues subject, <<-CRYSTAL
-        /f(o+)(bar?)/ === "fooba"
-        puts $~
-        "foobar" =~ /(o+)ba(r?)/
-        puts $1
-      CRYSTAL
+        /foo(bar)?/ =~ baz
+        "foobar" !~ /(o+)ba(r?)/
+        "hello" === world
+        CRYSTAL
     end
 
     it "fails for all comparison operators" do
@@ -52,12 +51,6 @@ module Ameba::Rule::Lint
         # ^^^^^^ error: Comparison operation is unused
           x != 2
         # ^^^^^^ error: Comparison operation is unused
-          x =~ 2
-        # ^^^^^^ error: Comparison operation is unused
-          x !~ 2
-        # ^^^^^^ error: Comparison operation is unused
-          x === 2
-        # ^^^^^^^ error: Comparison operation is unused
           x < 2
         # ^^^^^ error: Comparison operation is unused
           x <= 2

--- a/spec/ameba/rule/lint/unused_literal_spec.cr
+++ b/spec/ameba/rule/lint/unused_literal_spec.cr
@@ -52,6 +52,18 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    it "passes if a literal is the object of a call with args" do
+      expect_no_issues subject, <<-CRYSTAL
+          { error: "abc" }.to_json(context.response)
+        CRYSTAL
+    end
+
+    it "passes for a literal in a generic type" do
+      expect_no_issues subject, <<-CRYSTAL
+          StaticArray(1, 5)
+        CRYSTAL
+    end
+
     it "fails if literals are top-level" do
       expect_issue subject, <<-CRYSTAL
         1234

--- a/spec/ameba/rule/lint/unused_literal_spec.cr
+++ b/spec/ameba/rule/lint/unused_literal_spec.cr
@@ -54,13 +54,14 @@ module Ameba::Rule::Lint
 
     it "passes if a literal is the object of a call with args" do
       expect_no_issues subject, <<-CRYSTAL
-          { error: "abc" }.to_json(context.response)
+        { foo: "bar" }.to_json(io)
         CRYSTAL
     end
 
     it "passes for a literal in a generic type" do
       expect_no_issues subject, <<-CRYSTAL
-          StaticArray(1, 5)
+        StaticArray(Int32, 3)
+        Int32[3]
         CRYSTAL
     end
 

--- a/spec/ameba/rule/lint/unused_literal_spec.cr
+++ b/spec/ameba/rule/lint/unused_literal_spec.cr
@@ -65,6 +65,13 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
+    it "passes if a literal is passed to with or yield" do
+      expect_no_issues subject, <<-CRYSTAL
+        yield 1
+        with "2" yield :three
+        CRYSTAL
+    end
+
     it "fails if literals are top-level" do
       expect_issue subject, <<-CRYSTAL
         1234

--- a/src/ameba/ast/visitors/implicit_return_visitor.cr
+++ b/src/ameba/ast/visitors/implicit_return_visitor.cr
@@ -24,7 +24,7 @@ module Ameba::AST
       false
     end
 
-    def visit(node : Crystal::And | Crystal::Or) : Bool
+    def visit(node : Crystal::BinaryOp) : Bool
       @rule.test(@source, node, @stack > 0)
 
       if node.right.is_a?(Crystal::Call)
@@ -41,7 +41,7 @@ module Ameba::AST
     def visit(node : Crystal::Call) : Bool
       @rule.test(@source, node, @stack > 0)
 
-      if node.block || node.args.size > 0
+      if node.block || !node.args.empty?
         incr_stack { node.obj.try &.accept(self) }
       else
         node.obj.try &.accept(self)

--- a/src/ameba/ast/visitors/implicit_return_visitor.cr
+++ b/src/ameba/ast/visitors/implicit_return_visitor.cr
@@ -24,10 +24,24 @@ module Ameba::AST
       false
     end
 
+    def visit(node : Crystal::And | Crystal::Or) : Bool
+      @rule.test(@source, node, @stack > 0)
+
+      if node.right.is_a?(Crystal::Call)
+        incr_stack { node.left.accept(self) }
+      else
+        node.left.accept(self)
+      end
+
+      node.right.accept(self)
+
+      false
+    end
+
     def visit(node : Crystal::Call) : Bool
       @rule.test(@source, node, @stack > 0)
 
-      if node.block
+      if node.block || node.args.size > 0
         incr_stack { node.obj.try &.accept(self) }
       else
         node.obj.try &.accept(self)
@@ -131,6 +145,8 @@ module Ameba::AST
     end
 
     def visit(node : Crystal::TypeDeclaration) : Bool
+      @rule.test(@source, node, @stack > 0)
+
       incr_stack { node.value.try &.accept(self) }
 
       false
@@ -256,6 +272,18 @@ module Ameba::AST
       @rule.test(@source, node, @stack > 0)
 
       true
+    end
+
+    def visit(node : Crystal::Yield) : Bool
+      @rule.test(@source, node, @stack > 0)
+
+      incr_stack { node.exps.each &.accept(self) }
+
+      false
+    end
+
+    def visit(node : Crystal::Generic) : Bool
+      false
     end
 
     private def incr_stack(&) : Nil

--- a/src/ameba/rule/lint/unused_comparison.cr
+++ b/src/ameba/rule/lint/unused_comparison.cr
@@ -53,6 +53,9 @@ module Ameba::Rule::Lint
 
     def test(source, node : Crystal::Call, last_is_used : Bool)
       if !last_is_used && node.name.in?(COMPARISON_OPERATORS) && node.args.size == 1
+        return if node.name.in?("===", "=~") &&
+                  (node.obj.is_a?(Crystal::RegexLiteral) || node.args.first.is_a?(Crystal::RegexLiteral))
+
         issue_for node, MSG
       end
     end

--- a/src/ameba/rule/lint/unused_comparison.cr
+++ b/src/ameba/rule/lint/unused_comparison.cr
@@ -42,10 +42,7 @@ module Ameba::Rule::Lint
 
     MSG = "Comparison operation is unused"
 
-    COMPARISON_OPERATORS = %w[
-      == != =~ !~ ===
-      < <= > >= <=>
-    ]
+    COMPARISON_OPERATORS = %w[== != < <= > >= <=>]
 
     def test(source : Source)
       AST::ImplicitReturnVisitor.new(self, source)
@@ -53,9 +50,6 @@ module Ameba::Rule::Lint
 
     def test(source, node : Crystal::Call, last_is_used : Bool)
       if !last_is_used && node.name.in?(COMPARISON_OPERATORS) && node.args.size == 1
-        return if node.obj.is_a?(Crystal::RegexLiteral) ||
-                  node.args.first.is_a?(Crystal::RegexLiteral)
-
         issue_for node, MSG
       end
     end

--- a/src/ameba/rule/lint/unused_comparison.cr
+++ b/src/ameba/rule/lint/unused_comparison.cr
@@ -53,8 +53,8 @@ module Ameba::Rule::Lint
 
     def test(source, node : Crystal::Call, last_is_used : Bool)
       if !last_is_used && node.name.in?(COMPARISON_OPERATORS) && node.args.size == 1
-        return if node.name.in?("===", "=~") &&
-                  (node.obj.is_a?(Crystal::RegexLiteral) || node.args.first.is_a?(Crystal::RegexLiteral))
+        return if node.obj.is_a?(Crystal::RegexLiteral) ||
+                  node.args.first.is_a?(Crystal::RegexLiteral)
 
         issue_for node, MSG
       end


### PR DESCRIPTION
Follow up to #507 to fix some things I missed.

- Comparisons with a regex using `===` and `=~` have side effects, so they should not be counted.
- If the right of an And/Or is a call, the left should be counted, as it potentially has side effects / will control whether the right is called.
- If a call has args, count its object as being used, as it could have side effects.
- Fix yield and literals in generics having their expressions counted as unused.

See the specs for examples, mostly pulled from running this over the Crystal stdlib/compiler and seeing what it catches.