### PR TITLE
In case scope queue is empty call the rule with the current scope

### DIFF
--- a/spec/ameba/rule/lint/useless_assign_spec.cr
+++ b/spec/ameba/rule/lint/useless_assign_spec.cr
@@ -1011,6 +1011,18 @@ module Ameba::Rule::Lint
           CRYSTAL
       end
 
+      it "reports if it's not referenced at a top level + in a method" do
+        expect_issue subject, <<-CRYSTAL
+          a : String?
+          # ^{} error: Useless assignment to variable `a`
+
+          def foo
+            b : String?
+          # ^ error: Useless assignment to variable `b`
+          end
+          CRYSTAL
+      end
+
       it "reports if it's not referenced in a method" do
         expect_issue subject, <<-CRYSTAL
           def foo
@@ -1075,6 +1087,18 @@ module Ameba::Rule::Lint
         expect_issue subject, <<-CRYSTAL
           a = uninitialized U
           # ^{} error: Useless assignment to variable `a`
+          CRYSTAL
+      end
+
+      it "reports if uninitialized assignment is not referenced at a top level + in a method" do
+        expect_issue subject, <<-CRYSTAL
+          a = uninitialized U
+          # ^{} error: Useless assignment to variable `a`
+
+          def foo
+            b = uninitialized U
+          # ^ error: Useless assignment to variable `b`
+          end
           CRYSTAL
       end
 

--- a/src/ameba/ast/visitors/scope_visitor.cr
+++ b/src/ameba/ast/visitors/scope_visitor.cr
@@ -34,8 +34,12 @@ module Ameba::AST
 
       super @rule, @source
 
-      @scope_queue.each do |scope|
-        @rule.test @source, scope.node, scope
+      if @scope_queue.empty?
+        @rule.test @source, @current_scope.node, @current_scope
+      else
+        @scope_queue.each do |scope|
+          @rule.test @source, scope.node, scope
+        end
       end
     end
 
@@ -101,24 +105,18 @@ module Ameba::AST
     def end_visit(node : Crystal::Assign | Crystal::OpAssign)
       on_assign_end(node.target, node)
       @current_assign = nil
-
-      on_scope_end(node) if @current_scope.eql?(node)
     end
 
     # :nodoc:
     def end_visit(node : Crystal::MultiAssign)
       node.targets.each { |target| on_assign_end(target, node) }
       @current_assign = nil
-
-      on_scope_end(node) if @current_scope.eql?(node)
     end
 
     # :nodoc:
     def end_visit(node : Crystal::UninitializedVar)
       on_assign_end(node.var, node)
       @current_assign = nil
-
-      on_scope_end(node) if @current_scope.eql?(node)
     end
 
     # :nodoc:
@@ -137,8 +135,6 @@ module Ameba::AST
 
       on_assign_end(var, node)
       @current_assign = nil
-
-      on_scope_end(node) if @current_scope.eql?(node)
     end
 
     # :nodoc:


### PR DESCRIPTION
This PR changes the behavior of `AST::ScopeVisitor` to call the affected rule with the current scope in case scope queue is empty.