### PR TITLE
`Typing/MethodParameterTypeRestriction`: require types for double splat params

### DIFF
--- a/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
@@ -37,10 +37,9 @@ module Ameba::Rule::Typing
         CRYSTAL
     end
 
-    it "fails if a double splat method parameter doesn't have a type restriction" do
-      expect_issue subject, <<-CRYSTAL
+    it "passes if a double splat method parameter doesn't have a type restriction" do
+      expect_no_issues subject, <<-CRYSTAL
         def hello(**a) : String
-                  # ^ error: Method parameter should have a type restriction
           "hello world" + a.values.join(", ")
         end
         CRYSTAL
@@ -173,6 +172,20 @@ module Ameba::Rule::Typing
             def hello(a = "world")
                     # ^ error: Method parameter should have a type restriction
               "hello \#{a}"
+            end
+            CRYSTAL
+        end
+      end
+
+      context "#double_splat_parameters" do
+        rule = MethodParameterTypeRestriction.new
+        rule.double_splat_parameters = true
+
+        it "fails if a double splat method parameter doesn't have a type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            def hello(**a) : String
+                      # ^ error: Method parameter should have a type restriction
+              "hello world" + a.values.join(", ")
             end
             CRYSTAL
         end

--- a/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
@@ -13,6 +13,10 @@ module Ameba::Rule::Typing
         def hello(*a : String) : String
           "hello world" + a.join(", ")
         end
+
+        def hello(**a : String) : String
+          "hello world" + a.values.join(", ")
+        end
         CRYSTAL
     end
 
@@ -33,10 +37,11 @@ module Ameba::Rule::Typing
         CRYSTAL
     end
 
-    it "passes if a double splat method parameter doesn't have a type restriction" do
-      expect_no_issues subject, <<-CRYSTAL
-        def hello(a : String, **world) : String
-          "hello world" + a
+    it "fails if a double splat method parameter doesn't have a type restriction" do
+      expect_issue subject, <<-CRYSTAL
+        def hello(**a) : String
+                  # ^ error: Method parameter should have a type restriction
+          "hello world" + a.values.join(", ")
         end
         CRYSTAL
     end

--- a/src/ameba/rule/typing/method_parameter_type_restriction.cr
+++ b/src/ameba/rule/typing/method_parameter_type_restriction.cr
@@ -48,6 +48,7 @@ module Ameba::Rule::Typing
   #   DefaultValue: false
   #   PrivateMethods: false
   #   ProtectedMethods: false
+  #   DoubleSplatParameters: false
   #   BlockParameters: false
   # ```
   class MethodParameterTypeRestriction < Base
@@ -58,6 +59,7 @@ module Ameba::Rule::Typing
       default_value false
       private_methods false
       protected_methods false
+      double_splat_parameters false
       block_parameters false
     end
 
@@ -72,7 +74,7 @@ module Ameba::Rule::Typing
         issue_for arg, MSG
       end
 
-      if (arg = node.double_splat) && !arg.restriction
+      if double_splat_parameters? && (arg = node.double_splat) && !arg.restriction
         issue_for arg, MSG
       end
 

--- a/src/ameba/rule/typing/method_parameter_type_restriction.cr
+++ b/src/ameba/rule/typing/method_parameter_type_restriction.cr
@@ -72,7 +72,7 @@ module Ameba::Rule::Typing
         issue_for arg, MSG
       end
 
-      if (arg = node.double_splat) && !(arg.restriction)
+      if (arg = node.double_splat) && !arg.restriction
         issue_for arg, MSG
       end
 

--- a/src/ameba/rule/typing/method_parameter_type_restriction.cr
+++ b/src/ameba/rule/typing/method_parameter_type_restriction.cr
@@ -72,6 +72,10 @@ module Ameba::Rule::Typing
         issue_for arg, MSG
       end
 
+      if (arg = node.double_splat) && !(arg.restriction)
+        issue_for arg, MSG
+      end
+
       if block_parameters?
         node.block_arg.try do |block_arg|
           next if block_arg.restriction


### PR DESCRIPTION
For some reason thought this wasn't possible on my first pass. Should definitely be covered when this rule is enabled.