### PR TITLE
Initial proof of concept for expanding ameba's functionality with semantic information (#513)

### DIFF
--- a/spec/ameba/rule/lint/unknown_type_spec.cr
+++ b/spec/ameba/rule/lint/unknown_type_spec.cr
@@ -1,0 +1,28 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  subject = UnknownType.new
+
+  describe UnknownType do
+    it "passes if types are known" do
+      expect_no_issues subject, <<-CRYSTAL, semantic: true
+        a : Int32 = 1
+
+        def hello(name : String)
+          puts "Hello, \#{name}!"
+        end
+        CRYSTAL
+    end
+
+    it "fails if types are unknown" do
+      expect_issue subject, <<-CRYSTAL, semantic: true
+        count : Int3 = 1
+              # ^^^^ error: Unknown type
+        def hello(name : Str)
+                       # ^^^ error: Unknown type
+          puts "Hello, #{name}!"
+        end
+        CRYSTAL
+    end
+  end
+end

--- a/spec/ameba/runner_spec.cr
+++ b/spec/ameba/runner_spec.cr
@@ -54,13 +54,13 @@ module Ameba
         source = Source.new "", "source.cr"
 
         v1_0_0 = SemanticVersion.parse("1.0.0")
-        Runner.new(rules, [source], formatter, default_severity, false, v1_0_0).run.success?.should be_true
+        Runner.new(rules, [source], formatter, default_severity, false, false, v1_0_0).run.success?.should be_true
 
         v1_5_0 = SemanticVersion.parse("1.5.0")
-        Runner.new(rules, [source], formatter, default_severity, false, v1_5_0).run.success?.should be_false
+        Runner.new(rules, [source], formatter, default_severity, false, false, v1_5_0).run.success?.should be_false
 
         v1_10_0 = SemanticVersion.parse("1.10.0")
-        Runner.new(rules, [source], formatter, default_severity, false, v1_10_0).run.success?.should be_false
+        Runner.new(rules, [source], formatter, default_severity, false, false, v1_10_0).run.success?.should be_false
       end
 
       it "skips rule check if source is excluded" do

--- a/src/ameba/ast/visitors/semantic_visitor.cr
+++ b/src/ameba/ast/visitors/semantic_visitor.cr
@@ -1,0 +1,63 @@
+module Ameba::AST
+  # A simple visitor that iterates over a single files parser-only tree, resolving the
+  # namespaces to their corresponding namespace types.
+  #
+  # TODO: expand this to also include information about the current scope
+  class SemanticVisitor < BaseVisitor
+    getter context : SemanticContext
+    getter current_type : Crystal::ModuleType
+
+    def initialize(@rule, @source, @context : SemanticContext)
+      @current_type = @context.program
+
+      super(@rule, @source)
+    end
+
+    def visit(node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::LibDef)
+      @rule.test(@source, node, current_type)
+
+      # `Lint/NoSemanticInformation` should catch this edge case
+      type = current_type.lookup_type?(node.name).try(&.as?(Crystal::ModuleType))
+
+      # Don't visit bodies of types we don't have any semantic information for.
+      # This is reported by `Lint/NoSemanticInformation`
+      return false unless type
+
+      pushing_type(type) do
+        node.body.accept(self)
+      end
+
+      false
+    end
+
+    def visit(node : Crystal::EnumDef)
+      @rule.test(@source, node, current_type)
+
+      # `Lint/NoSemanticInformation` should catch this edge case
+      type = current_type.lookup_type?(node.name).try(&.as?(Crystal::ModuleType))
+
+      # Don't visit bodies of types we don't have any semantic information for.
+      # This is reported by `Lint/NoSemanticInformation`
+      return false unless type
+
+      pushing_type(type) do
+        node.members.each &.accept(self)
+      end
+
+      false
+    end
+
+    def visit(node) : Bool
+      @rule.test(@source, node, current_type)
+
+      true
+    end
+
+    private def pushing_type(type : Crystal::ModuleType, &)
+      old_type = @current_type
+      @current_type = type
+      yield
+      @current_type = old_type
+    end
+  end
+end

--- a/src/ameba/cli/cmd.cr
+++ b/src/ameba/cli/cmd.cr
@@ -23,6 +23,7 @@ module Ameba::Cli
     property? colors = true
     property? without_affected_code = false
     property? autocorrect = false
+    property? semantic = false
   end
 
   def run(args = ARGV) : Nil
@@ -151,6 +152,10 @@ module Ameba::Cli
       parser.on("--stdin-filename FILENAME", "Read source from STDIN") do |file|
         opts.stdin_filename = file
       end
+
+      parser.on("--semantic", "Semantic analysis") do
+        opts.semantic = true
+      end
     end
 
     opts
@@ -169,6 +174,9 @@ module Ameba::Cli
     end
     if fail_level = opts.fail_level
       config.severity = fail_level
+    end
+    if semantic = opts.semantic?
+      config.semantic = semantic
     end
 
     configure_formatter(config, opts)

--- a/src/ameba/config.cr
+++ b/src/ameba/config.cr
@@ -96,6 +96,10 @@ class Ameba::Config
   # Returns `true` if correctable issues should be autocorrected.
   property? autocorrect = false
 
+  # Returns `true` if semantic context should be used for linting.
+  # TODO: should this be an enum for chosing between top-level and compile?
+  property? semantic = false
+
   # Returns a filename if reading source file from STDIN.
   property stdin_filename : String?
 

--- a/src/ameba/environment.cr
+++ b/src/ameba/environment.cr
@@ -1,0 +1,25 @@
+# Need to point to the stdlib of the current Crystal installation.
+# TODO: verify this works on Windows
+#
+# https://github.com/elbywan/crystalline/blob/bfb0b3b912c64f4f316d56a8e7481261c0edfdca/src/crystalline/main.cr#L25
+module Ameba::EnvironmentConfig
+  # Add the `crystal env` environment variables to the current env.
+  def self.run : Nil
+    initialize_from_crystal_env.each do |k, v|
+      ENV[k] = v
+    end
+  end
+
+  private def self.initialize_from_crystal_env
+    crystal_env
+      .lines
+      .map(&.split('='))
+      .to_h
+  end
+
+  private def self.crystal_env
+    String.build do |io|
+      Process.run("crystal", ["env"], output: io)
+    end
+  end
+end

--- a/src/ameba/rule/base.cr
+++ b/src/ameba/rule/base.cr
@@ -39,6 +39,13 @@ module Ameba::Rule
       AST::NodeVisitor.new self, source
     end
 
+    # This method can be overridden by rules if they wish to add support for using
+    # semantic information when it is available. By default, the semantic information
+    # is ignored to preserve compatibility with parse-only rules.
+    def test(source : Source, context : SemanticContext?)
+      test(source)
+    end
+
     # NOTE: Can't be abstract
     def test(source : Source, node : Crystal::ASTNode, *opts)
     end
@@ -50,8 +57,8 @@ module Ameba::Rule
     # source = MyRule.new.catch(source)
     # source.valid?
     # ```
-    def catch(source : Source)
-      source.tap { test source }
+    def catch(source : Source, context : SemanticContext? = nil)
+      source.tap { test source, context }
     end
 
     # Returns a name of this rule, which is basically a class name.

--- a/src/ameba/rule/lint/no_semantic_information.cr
+++ b/src/ameba/rule/lint/no_semantic_information.cr
@@ -1,0 +1,37 @@
+module Ameba::Rule::Lint
+  # A rule that reports when there's no semantic information available for a given type.
+  # This usually happens when there's a file in the codebase not covered by an entrypoint.
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/NoSemanticInformation:
+  #   Enabled: true
+  # ```
+  class NoSemanticInformation < Base
+    properties do
+      since_version "1.7.0"
+      description "Reports types that don't have any semantic information available"
+      severity :warning
+    end
+
+    MSG = "This type doesn't have any semantic information (double check the ameba entrypoints)"
+
+    def test(source, context : SemanticContext?)
+      return if context.nil?
+
+      AST::SemanticVisitor.new self, source, context
+    end
+
+    def test(
+      source,
+      node : Crystal::ClassDef | Crystal::ModuleDef |
+             Crystal::LibDef | Crystal::EnumDef,
+      current_type : Crystal::Type,
+    )
+      return if current_type.lookup_type?(node.name)
+
+      issue_for node.name, MSG
+    end
+  end
+end

--- a/src/ameba/rule/lint/semantic.cr
+++ b/src/ameba/rule/lint/semantic.cr
@@ -1,0 +1,34 @@
+module Ameba::Rule::Lint
+  # A rule that reports invalid Crystal semantics.
+  class Semantic < Base
+    properties do
+      since_version "1.7.0"
+      description "Reports invalid Crystal semantics"
+      severity :error
+    end
+
+    def test(source, context : SemanticContext?)
+      return
+    end
+
+    def test(source, sources : Array(Source)) : SemanticContext?
+      SemanticContext.for_entrypoint([source])
+    rescue ex : Crystal::TypeException
+      # TODO: other exception types
+
+      # Attach to the entrypoint if it's not one of our sources
+      source = sources.find(source) { |i| i.path == ex.@filename }
+      filename = ex.@filename || source.path
+
+      location = Crystal::Location.new(
+        filename: filename,
+        line_number: ex.line_number || 0,
+        column_number: ex.column_number
+      )
+
+      issue_for location, location, ex.message.to_s
+
+      nil
+    end
+  end
+end

--- a/src/ameba/rule/lint/unknown_type.cr
+++ b/src/ameba/rule/lint/unknown_type.cr
@@ -1,0 +1,109 @@
+module Ameba::Rule::Lint
+  # A rule that uses semantic information to check parameter and type declaration restrictions
+  # to ensure that those types exist within the current semantic context, even if the
+  # code isn't used during compilation.
+  #
+  # By default, the Crystal compiler does not do any semantic analysis to code that isn't used.
+  # That can lead to issues like this, where a typo can cause unexpected behavior:
+  #
+  # ```
+  # class MessageHandler
+  #   def on_request(msg)
+  #     # generic message handling
+  #   end
+
+  #   def on_request(msg : SpecificMessageType)
+  #     # specific message handling
+  #   end
+  # end
+  # ```
+  #
+  # If `SpecificMessageType` is misspelled, this code will compile and execute normally, but
+  # the method overloading won't happen for the specific message type.
+  #
+  # This is considered invalid:
+  #
+  # ```
+  # count : Int3 = 1
+  #
+  # def hello(name : Str)
+  #   puts "Hello, #{name}!"
+  # end
+  # ```
+  #
+  # And this is considered valid:
+  #
+  # ```
+  # count : Int32 = 1
+  #
+  # def hello(name : String)
+  #   puts "Hello, #{name}!"
+  # end
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/UnknownType:
+  #   Enabled: true
+  # ```
+  class UnknownType < Base
+    properties do
+      since_version "1.7.0"
+      description "Reports unknown types"
+      severity :error
+    end
+
+    MSG = "Unknown type"
+
+    def test(source, context : SemanticContext?)
+      return if context.nil?
+
+      AST::SemanticVisitor.new self, source, context
+    end
+
+    def test(source, node : Crystal::TypeDeclaration, current_type : Crystal::Type)
+      return if current_type.lookup_type?(node.declared_type)
+
+      validate_type(source, node.declared_type, current_type)
+    end
+
+    def test(source, node : Crystal::Arg, current_type : Crystal::Type)
+      return if (restriction = node.restriction).nil?
+
+      validate_type(source, restriction, current_type)
+    end
+
+    private def validate_type(source, node : Crystal::ASTNode, current_type : Crystal::Type) : Nil
+      case node
+      when Crystal::Path
+        return if current_type.lookup_type?(node)
+
+        issue_for node, MSG
+      when Crystal::Union
+        node.types.each do |type|
+          validate_type(source, type, current_type)
+        end
+      when Crystal::ProcNotation
+        node.inputs.try &.each { |i| validate_type(source, i, current_type) }
+        node.output.try { |i| validate_type(source, i, current_type) }
+      when Crystal::TypeOf
+        node.expressions.each do |type|
+          validate_type(source, type, current_type)
+        end
+      when Crystal::Generic
+        validate_type(source, node.name, current_type)
+
+        node.type_vars.each do |type|
+          validate_type(source, type, current_type)
+        end
+
+        node.named_args.try &.each do |arg|
+          validate_type(source, arg.value, current_type)
+        end
+      when Crystal::Underscore, Crystal::Self
+        # Okay
+      end
+    end
+  end
+end

--- a/src/ameba/rule/performance/base.cr
+++ b/src/ameba/rule/performance/base.cr
@@ -3,7 +3,7 @@ require "../base"
 module Ameba::Rule::Performance
   # A general base class for performance rules.
   abstract class Base < Ameba::Rule::Base
-    def catch(source : Source)
+    def catch(source : Source, context : SemanticContext? = nil)
       source.spec? ? source : super
     end
   end

--- a/src/ameba/runner.cr
+++ b/src/ameba/runner.cr
@@ -43,11 +43,16 @@ module Ameba
     # A syntax rule which always inspects a source first
     @syntax_rule = Rule::Lint::Syntax.new
 
+    # A semantic rule which generates semantic information about the sources
+    @semantic_rule = Rule::Lint::Semantic.new
+
     # Checks for unneeded disable directives. Always inspects a source last
     @unneeded_disable_directive_rule : Rule::Base?
 
     # Returns `true` if correctable issues should be autocorrected.
     private getter? autocorrect : Bool
+
+    private getter? semantic : Bool
 
     # Returns an ameba version up to which the rules should be ran.
     property version : SemanticVersion?
@@ -68,11 +73,12 @@ module Ameba
         config.formatter,
         config.severity,
         config.autocorrect?,
+        config.semantic?,
         config.version,
       )
     end
 
-    protected def initialize(rules, sources, @formatter, @severity, @autocorrect = false, @version = nil)
+    protected def initialize(rules, sources, @formatter, @severity, @autocorrect = false, @semantic = false, @version = nil)
       @sources = sources.sort_by(&.path)
       @rules =
         rules.select { |rule| rule_runnable?(rule, @version) }
@@ -103,10 +109,33 @@ module Ameba
     def run
       @formatter.started @sources
 
+      if semantic?
+        context = begin
+          # TODO: multiple entrypoints
+          entrypoint = @sources.find! { |i| i.path == "src/cli.cr" }
+          @semantic_rule.test(entrypoint, @sources)
+        rescue ex
+          # TODO: just for dev / testing, everything should be caught by the rule itself
+          puts "failed to run semantic\n\n#{ex.class}\n#{ex}\n\n#{ex.backtrace.try(&.join("\n"))}"
+          exit 1
+        end
+
+        # test the semantic rules
+        run_sources(context)
+      else
+        run_sources
+      end
+
+      self
+    ensure
+      @formatter.finished @sources
+    end
+
+    private def run_sources(context : SemanticContext? = nil) : Nil
       channels = @sources.map { Channel(Exception?).new }
       @sources.zip(channels).each do |source, channel|
         spawn do
-          run_source(source)
+          run_source(source, context)
         rescue e
           channel.send(e)
         else
@@ -117,13 +146,10 @@ module Ameba
       channels.each do |chan|
         chan.receive.try { |e| raise e }
       end
-
-      self
-    ensure
-      @formatter.finished @sources
     end
 
-    private def run_source(source) : Nil
+    private def run_source(source, context : SemanticContext? = nil) : Nil
+      # TODO: pass the current context to the formatters
       @formatter.source_started source
 
       # This variable is a 2D array used to track corrected issues after each
@@ -143,7 +169,7 @@ module Ameba
 
         @rules.each do |rule|
           next if rule.excluded?(source)
-          rule.test(source)
+          rule.test(source, context)
         end
         check_unneeded_directives(source)
         break unless autocorrect? && source.correct?

--- a/src/ameba/semantic_context.cr
+++ b/src/ameba/semantic_context.cr
@@ -1,0 +1,103 @@
+require "llvm/lib_llvm"
+require "compiler/crystal/annotatable"
+require "compiler/crystal/tools/dependencies"
+require "compiler/crystal/compiler"
+require "compiler/crystal/config"
+require "compiler/crystal/crystal_path"
+require "compiler/crystal/error"
+require "compiler/crystal/exception"
+require "compiler/crystal/formatter"
+require "compiler/crystal/loader"
+require "compiler/crystal/macros"
+require "compiler/crystal/program"
+require "compiler/crystal/progress_tracker"
+require "compiler/crystal/semantic"
+require "compiler/crystal/syntax"
+require "compiler/crystal/types"
+require "compiler/crystal/syntax/**"
+require "compiler/crystal/semantic/**"
+require "compiler/crystal/macros/**"
+require "compiler/crystal/codegen/**"
+
+class Ameba::SemanticContext
+  def self.for_entrypoint(sources : Array(Source)) : SemanticContext
+    EnvironmentConfig.run
+
+    crystal_sources = sources.map { |i| Crystal::Compiler::Source.new(i.path, i.code) }
+
+    result = semantic(crystal_sources)
+
+    new(result.program, result.node)
+  end
+
+  def self.for_entrypoint(path : String) : SemanticContext
+    EnvironmentConfig.run
+
+    sources = [Crystal::Compiler::Source.new(path, File.read(path))]
+
+    result = semantic(sources)
+
+    new(result.program, result.node)
+  end
+
+  # Generates a top-level semantic of just the primitives (Int32, String, etc)
+  def self.primitive_context(code : String) : SemanticContext
+    EnvironmentConfig.run
+
+    source = Source.new("", %(require "primitive"\n#{code}))
+    node = source.ast
+
+    dev_null = File.open(File::NULL, "w")
+
+    program = Crystal::Program.new
+    program.color = false
+    program.wants_doc = false
+    program.stdout = dev_null
+
+    node = program.normalize node
+    root, _ = program.top_level_semantic(node)
+
+    new(program, root)
+  end
+
+  # Executes the Crystal compiler to generate top-level semantic information about
+  # the given code. Will raise if there are semantic errors.
+  def self.semantic(sources : Array(Crystal::Compiler::Source)) : Crystal::Compiler::Result
+    EnvironmentConfig.run
+
+    reply_channel = Channel(Crystal::Compiler::Result | Exception).new
+
+    spawn do
+      dev_null = File.open(File::NULL, "w")
+
+      compiler = Crystal::Compiler.new
+      compiler.no_codegen = true
+      compiler.color = false
+      compiler.no_cleanup = true
+      compiler.wants_doc = false
+      compiler.stdout = dev_null
+      compiler.stderr = dev_null
+
+      reply = compiler.top_level_semantic(sources)
+
+      reply_channel.send(reply)
+    rescue e : Exception
+      reply_channel.send(e)
+    ensure
+      dev_null.try &.close
+    end
+
+    result = reply_channel.receive
+
+    # Should fail `Lint/Semantic`
+    raise result if result.is_a? Exception
+
+    result
+  end
+
+  getter program : Crystal::Program
+  getter node : Crystal::ASTNode
+
+  def initialize(@program, @node)
+  end
+end


### PR DESCRIPTION
Some notes:
- Entrypoints are currently not implemented, still work to do to figure out how to support that
- Requires Crystal installed on the system it's running (previously this was not a requirement)
- Only does top-level semantic (for performance) and is gated behind a `--semantic` flag
  - It may be worth changing the `--semantic` flag into an enum to choose between top-level and full semantic
  - Top-level was chosen for performance reasons