### PR TITLE
Refactor newly added rules' specs

### DIFF
--- a/spec/ameba/rule/lint/shadowed_argument_spec.cr
+++ b/spec/ameba/rule/lint/shadowed_argument_spec.cr
@@ -42,7 +42,7 @@ module Ameba::Rule::Lint
 
     it "reports if there is a shadowed proc argument" do
       s = Source.new %(
-        ->(x : Int32) {
+        -> (x : Int32) {
           x = 20
           x
         }

--- a/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
+++ b/spec/ameba/rule/lint/shadowing_outer_local_var_spec.cr
@@ -13,8 +13,8 @@ module Ameba::Rule::Lint
             bar
           end
 
-          -> (baz : Int32) {}
-          -> (bar : String) {}
+          -> (baz : Int32) { }
+          -> (bar : String) { }
         end
         CRYSTAL
     end
@@ -67,7 +67,7 @@ module Ameba::Rule::Lint
         def some_method
           foo = 1
 
-          -> (foo : Int32) {}
+          -> (foo : Int32) { }
             # ^^^^^^^^^^^ error: Shadowing outer local variable `foo`
         end
         CRYSTAL

--- a/spec/ameba/rule/lint/shared_var_in_fiber_spec.cr
+++ b/spec/ameba/rule/lint/shared_var_in_fiber_spec.cr
@@ -140,7 +140,7 @@ module Ameba::Rule::Lint
       expect_no_issues subject, <<-CRYSTAL
         i = 0
         while i < 10
-          proc = ->(x : Int32) do
+          proc = -> (x : Int32) do
             spawn do
             puts(x)
             end

--- a/spec/ameba/rule/lint/trailing_rescue_exception_spec.cr
+++ b/spec/ameba/rule/lint/trailing_rescue_exception_spec.cr
@@ -6,14 +6,14 @@ module Ameba::Rule::Lint
 
     it "passes for trailing rescue with literal values" do
       expect_no_issues subject, <<-CRYSTAL
-        puts "hello" rescue "world"
-        puts :meow rescue 1234
+        puts "foo" rescue "bar"
+        puts :foo rescue 42
         CRYSTAL
     end
 
     it "passes for trailing rescue with class initialization" do
       expect_no_issues subject, <<-CRYSTAL
-        puts "hello" rescue MyClass.new
+        puts "foo" rescue MyClass.new
         CRYSTAL
     end
 

--- a/spec/ameba/rule/lint/unused_argument_spec.cr
+++ b/spec/ameba/rule/lint/unused_argument_spec.cr
@@ -15,7 +15,7 @@ module Ameba::Rule::Lint
           i + 1
         end
 
-        ->(i : Int32) { i + 1 }
+        -> (i : Int32) { i + 1 }
         CRYSTAL
     end
 
@@ -296,7 +296,7 @@ module Ameba::Rule::Lint
           rule.ignore_procs = true
 
           expect_no_issues rule, <<-CRYSTAL
-            ->(a : Int32) {}
+            -> (a : Int32) { }
             CRYSTAL
         end
 
@@ -305,8 +305,8 @@ module Ameba::Rule::Lint
           rule.ignore_procs = false
 
           expect_issue rule, <<-CRYSTAL
-            ->(a : Int32) {}
-             # ^^^^^^^^^ error: Unused argument `a`. If it's necessary, use `_a` as an argument name to indicate that it won't be used.
+            -> (a : Int32) { }
+              # ^^^^^^^^^ error: Unused argument `a`. If it's necessary, use `_a` as an argument name to indicate that it won't be used.
             CRYSTAL
         end
       end

--- a/spec/ameba/rule/lint/useless_assign_spec.cr
+++ b/spec/ameba/rule/lint/useless_assign_spec.cr
@@ -25,7 +25,7 @@ module Ameba::Rule::Lint
 
     it "reports a useless assignment in a proc" do
       expect_issue subject, <<-CRYSTAL
-        ->() {
+        -> () {
           a = 2
         # ^ error: Useless assignment to variable `a`
         }
@@ -46,7 +46,7 @@ module Ameba::Rule::Lint
     it "reports a useless assignment in a proc inside def" do
       expect_issue subject, <<-CRYSTAL
         def method
-          ->() {
+          -> () {
             a = 2
           # ^ error: Useless assignment to variable `a`
           }
@@ -65,7 +65,7 @@ module Ameba::Rule::Lint
       expect_issue subject, <<-CRYSTAL
         def method
           3.times do
-            ->() {
+            -> () {
               a = 2
             # ^ error: Useless assignment to variable `a`
             }
@@ -239,7 +239,7 @@ module Ameba::Rule::Lint
       expect_no_issues subject, <<-CRYSTAL
         def method
           called = false
-          ->() { called = true }
+          -> () { called = true }
           called
         end
         CRYSTAL

--- a/spec/ameba/rule/style/redundant_self_spec.cr
+++ b/spec/ameba/rule/style/redundant_self_spec.cr
@@ -87,7 +87,7 @@ module Ameba::Rule::Style
           end
 
           def bar
-            ->(foo : Int32) { self.foo + foo }
+            -> (foo : Int32) { self.foo + foo }
           end
         end
         CRYSTAL

--- a/spec/ameba/rule/typing/macro_call_argument_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/macro_call_argument_type_restriction_spec.cr
@@ -6,39 +6,42 @@ module Ameba::Rule::Typing
 
     it "passes if macro call args have type restrictions" do
       expect_no_issues subject, <<-CRYSTAL
-        class Greeter
-          getter name : String?
-          class_getter age : Int32 = 0
-          setter tasks : Array(String) = [] of String
-          class_setter queue : Array(Int32)?
-          property task_mutex : Mutex = Mutex.new
-          class_property asdf : String
+        class Foo
+          getter foo : Int32?
+          setter bar : Array(Int32)?
+          property baz : Bool?
         end
 
         record Task,
           cmd : String,
-          args : Array(String) = %w[]
+          args : Array(String)
+        CRYSTAL
+    end
+
+    it "passes if macro call args have default values" do
+      expect_no_issues subject, <<-CRYSTAL
+        class Foo
+          getter foo = 0
+          setter bar = [] of Int32
+          property baz = true
+        end
+
+        record Task,
+          cmd = "",
+          args = %w[]
         CRYSTAL
     end
 
     it "fails if a macro call arg doesn't have a type restriction" do
       expect_issue subject, <<-CRYSTAL
-        class Greeter
-          getter name
+        class Foo
+          getter foo
+               # ^^^ error: Argument should have a type restriction
+          getter :bar
                # ^^^^ error: Argument should have a type restriction
-          getter :age
-               # ^^^^ error: Argument should have a type restriction
-          getter "height"
-               # ^^^^^^^^ error: Argument should have a type restriction
+          getter "baz"
+               # ^^^^^ error: Argument should have a type restriction
         end
-        CRYSTAL
-    end
-
-    it "passes if a record call arg with a default value doesn't have a type restriction" do
-      expect_no_issues subject, <<-CRYSTAL
-        record Task,
-          cmd : String,
-          args = %[]
         CRYSTAL
     end
 
@@ -49,9 +52,9 @@ module Ameba::Rule::Typing
 
         it "fails if a macro call arg with a default value doesn't have a type restriction" do
           expect_issue rule, <<-CRYSTAL
-            class Greeter
-              getter name = "Kenobi"
-                   # ^^^^ error: Argument should have a type restriction
+            class Foo
+              getter foo = "bar"
+                   # ^^^ error: Argument should have a type restriction
             end
             CRYSTAL
         end

--- a/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_parameter_type_restriction_spec.cr
@@ -6,53 +6,50 @@ module Ameba::Rule::Typing
 
     it "passes if a method parameter has a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello(a : String, b : _) : String
-          "hello world" + a + b
+        def foo(bar : String, baz : _) : String
         end
+        CRYSTAL
+    end
 
-        def hello(*a : String) : String
-          "hello world" + a.join(", ")
+    it "passes if a splat method parameter has a type restriction" do
+      expect_no_issues subject, <<-CRYSTAL
+        def foo(*bar : String) : String
         end
         CRYSTAL
     end
 
     it "fails if a splat method parameter with a name doesn't have a type restriction" do
       expect_issue subject, <<-CRYSTAL
-        def hello(*a) : String
-                 # ^ error: Method parameter should have a type restriction
-          "hello world" + a.join(", ")
+        def foo(*bar) : String
+               # ^ error: Method parameter should have a type restriction
         end
         CRYSTAL
     end
 
     it "passes if a splat parameter without a name doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello(hello : String, *, world : String = "world") : String
-          hello + world
+        def foo(bar : String, *, baz : String = "bat") : String
         end
         CRYSTAL
     end
 
     it "passes if a double splat method parameter doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello(a : String, **world) : String
-          "hello world" + a
+        def foo(bar : String, **opts) : String
         end
         CRYSTAL
     end
 
     it "passes if a private method parameter doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        private def hello(a)
-          "hello world" + a
+        private def foo(bar)
         end
         CRYSTAL
     end
 
     it "passes if a protected method parameter doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        protected def hello(a)
-          "hello world" + a
+        protected def foo(bar)
         end
         CRYSTAL
     end
@@ -66,31 +63,31 @@ module Ameba::Rule::Typing
 
     it "fails if a public method parameter doesn't have a type restriction" do
       expect_issue subject, <<-CRYSTAL
-        def hello(a)
-                # ^ error: Method parameter should have a type restriction
-          "hello world" + a
+        def foo(bar)
+              # ^ error: Method parameter should have a type restriction
         end
+        CRYSTAL
+    end
 
-        def hello(a, ext b)
-                # ^ error: Method parameter should have a type restriction
+    it "fails if a public method external parameter doesn't have a type restriction" do
+      expect_issue subject, <<-CRYSTAL
+        def foo(bar, ext baz)
+              # ^ error: Method parameter should have a type restriction
                    # ^ error: Method parameter should have a type restriction
-          "hello world" + a + b
         end
         CRYSTAL
     end
 
     it "passes if a method parameter with a default value doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello(a = "jim")
-          "hello there, " + a
+        def foo(bar = "baz")
         end
         CRYSTAL
     end
 
     it "passes if a block parameter doesn't have a type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello(&)
-          "hello there"
+        def foo(&)
         end
         CRYSTAL
     end
@@ -102,30 +99,30 @@ module Ameba::Rule::Typing
 
         it "passes if a method has a parameter type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            private def hello(a : String) : String
-              "hello world" + a
+            private def foo(bar : String) : String
             end
             CRYSTAL
         end
 
         it "passes if a protected method parameter doesn't have a type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            protected def hello(a)
-              "hello world"
+            protected def foo(bar)
             end
             CRYSTAL
         end
 
-        it "fails if a public or private method doesn't have a parameter type restriction" do
+        it "fails if a public method doesn't have a parameter type restriction" do
           expect_issue rule, <<-CRYSTAL
-            def hello(a)
-                    # ^ error: Method parameter should have a type restriction
-              "hello world"
+            def foo(bar)
+                  # ^ error: Method parameter should have a type restriction
             end
+            CRYSTAL
+        end
 
-            private def hello(a)
-                            # ^ error: Method parameter should have a type restriction
-              "hello world"
+        it "fails if a private method doesn't have a parameter type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            private def foo(bar)
+                          # ^ error: Method parameter should have a type restriction
             end
             CRYSTAL
         end
@@ -137,30 +134,30 @@ module Ameba::Rule::Typing
 
         it "passes if a method has a parameter type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            protected def hello(a : String) : String
-              "hello world" + a
+            protected def foo(bar : String) : String
             end
             CRYSTAL
         end
 
         it "passes if a private method parameter doesn't have a type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            private def hello(a)
-              "hello world"
+            private def foo(bar)
             end
             CRYSTAL
         end
 
-        it "fails if a public or protected method doesn't have a parameter type restriction" do
+        it "fails if a public method doesn't have a parameter type restriction" do
           expect_issue rule, <<-CRYSTAL
-            def hello(a)
-                    # ^ error: Method parameter should have a type restriction
-              "hello world"
+            def foo(bar)
+                  # ^ error: Method parameter should have a type restriction
             end
+            CRYSTAL
+        end
 
-            protected def hello(a)
-                              # ^ error: Method parameter should have a type restriction
-              "hello world"
+        it "fails if a protected method doesn't have a parameter type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            protected def foo(bar)
+                            # ^ error: Method parameter should have a type restriction
             end
             CRYSTAL
         end
@@ -171,10 +168,9 @@ module Ameba::Rule::Typing
           rule = MethodParameterTypeRestriction.new
           rule.default_value = true
 
-          expect_issue rule, <<-'CRYSTAL'
-            def hello(a = "world")
-                    # ^ error: Method parameter should have a type restriction
-              "hello #{a}"
+          expect_issue rule, <<-CRYSTAL
+            def foo(bar = "baz")
+                  # ^ error: Method parameter should have a type restriction
             end
             CRYSTAL
         end
@@ -186,18 +182,16 @@ module Ameba::Rule::Typing
 
         it "fails if a block parameter without a name doesn't have a type restriction" do
           expect_issue rule, <<-CRYSTAL
-            def hello(&)
-                     # ^ error: Method parameter should have a type restriction
-              "hello"
+            def foo(&)
+                   # ^ error: Method parameter should have a type restriction
             end
             CRYSTAL
         end
 
         it "fails if a block parameter with a name doesn't have a type restriction" do
-          expect_issue rule, <<-'CRYSTAL'
-            def hello(&a)
-                     # ^ error: Method parameter should have a type restriction
-              "hello, #{a.call}"
+          expect_issue rule, <<-CRYSTAL
+            def foo(&block)
+                   # ^ error: Method parameter should have a type restriction
             end
             CRYSTAL
         end

--- a/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/method_return_type_restriction_spec.cr
@@ -4,35 +4,42 @@ module Ameba::Rule::Typing
   describe MethodReturnTypeRestriction do
     subject = MethodReturnTypeRestriction.new
 
-    it "passes if a method has a return type restriction" do
+    it "passes if a public method has a return type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        def hello : String
-          "hello world"
-        end
-
-        private def hello : String
-          "hello world"
-        end
-
-        protected def hello : String
-          "hello world"
+        def foo : String
         end
         CRYSTAL
     end
 
-    it "passes if a private or protected method doesn't have a return type restriction" do
+    it "passes if a private method has a return type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        private def hello
-          "hello world"
-        end
-
-        protected def hello
-          "hello world"
+        private def foo : String
         end
         CRYSTAL
     end
 
-    it "passes if a method has a `:nodoc:` annotation" do
+    it "passes if a protected method has a return type restriction" do
+      expect_no_issues subject, <<-CRYSTAL
+        protected def foo : String
+        end
+        CRYSTAL
+    end
+
+    it "passes if a private method doesn't have a return type restriction" do
+      expect_no_issues subject, <<-CRYSTAL
+        private def foo
+        end
+        CRYSTAL
+    end
+
+    it "passes if a protected method doesn't have a return type restriction" do
+      expect_no_issues subject, <<-CRYSTAL
+        protected def foo
+        end
+        CRYSTAL
+    end
+
+    it "passes if a public method has a `:nodoc:` annotation" do
       expect_no_issues subject, <<-CRYSTAL
         # :nodoc:
         def foo; end
@@ -41,9 +48,8 @@ module Ameba::Rule::Typing
 
     it "fails if a public method doesn't have a return type restriction" do
       expect_issue subject, <<-CRYSTAL
-        def hello
-        # ^^^^^^^ error: Method should have a return type restriction
-          "hello world"
+        def foo
+        # ^^^^^ error: Method should have a return type restriction
         end
         CRYSTAL
     end
@@ -53,40 +59,46 @@ module Ameba::Rule::Typing
         rule = MethodReturnTypeRestriction.new
         rule.private_methods = true
 
-        it "passes if a method has a return type restriction" do
+        it "passes if a public method has a return type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            def hello : String
-              "hello world"
+            def foo : String
             end
+            CRYSTAL
+        end
 
-            private def hello : String
-              "hello world"
+        it "passes if a private method has a return type restriction" do
+          expect_no_issues rule, <<-CRYSTAL
+            private def foo : String
             end
+            CRYSTAL
+        end
 
-            protected def hello : String
-              "hello world"
+        it "passes if a protected method has a return type restriction" do
+          expect_no_issues rule, <<-CRYSTAL
+            protected def foo : String
             end
             CRYSTAL
         end
 
         it "passes if a protected method doesn't have a return type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            protected def hello
-              "hello world"
+            protected def foo
             end
             CRYSTAL
         end
 
-        it "fails if a public or private method doesn't have a return type restriction" do
+        it "fails if a public method doesn't have a return type restriction" do
           expect_issue rule, <<-CRYSTAL
-            def hello
-            # ^^^^^^^ error: Method should have a return type restriction
-              "hello world"
+            def foo
+            # ^^^^^ error: Method should have a return type restriction
             end
+            CRYSTAL
+        end
 
-            private def hello
-                  # ^^^^^^^^^ error: Method should have a return type restriction
-              "hello world"
+        it "fails if a private method doesn't have a return type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            private def foo
+                  # ^^^^^^^ error: Method should have a return type restriction
             end
             CRYSTAL
         end
@@ -96,32 +108,39 @@ module Ameba::Rule::Typing
         rule = MethodReturnTypeRestriction.new
         rule.protected_methods = true
 
-        it "passes if a method has a return type restriction" do
+        it "passes if a public method has a return type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            protected def hello : String
-              "hello world"
+            def foo : String
             end
             CRYSTAL
         end
 
         it "passes if a private method doesn't have a return type restriction" do
           expect_no_issues rule, <<-CRYSTAL
-            private def hello
-              "hello world"
+            private def foo
             end
             CRYSTAL
         end
 
-        it "fails if a public or protected method doesn't have a return type restriction" do
-          expect_issue rule, <<-CRYSTAL
-            def hello
-            # ^^^^^^^ error: Method should have a return type restriction
-              "hello world"
+        it "passes if a protected method has a return type restriction" do
+          expect_no_issues rule, <<-CRYSTAL
+            protected def foo : String
             end
+            CRYSTAL
+        end
 
-            protected def hello
-                    # ^^^^^^^^^ error: Method should have a return type restriction
-              "hello world"
+        it "fails if a public method doesn't have a return type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            def foo
+            # ^^^^^ error: Method should have a return type restriction
+            end
+            CRYSTAL
+        end
+
+        it "fails if a protected method doesn't have a return type restriction" do
+          expect_issue rule, <<-CRYSTAL
+            protected def foo
+                    # ^^^^^^^ error: Method should have a return type restriction
             end
             CRYSTAL
         end

--- a/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
@@ -6,14 +6,14 @@ module Ameba::Rule::Typing
 
     it "passes if a proc literal has a return type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        my_proc = -> (var : String) : Nil { puts var }
+        foo = -> (bar : String) : Nil { }
         CRYSTAL
     end
 
     it "fails if a proc literal doesn't have a return type restriction" do
       expect_issue subject, <<-CRYSTAL
-        my_proc = -> (var : String) { puts var }
-                # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literal should have a return type restriction
+        foo = -> (bar : String) { }
+            # ^^^^^^^^^^^^^^^^^^^^^ error: Proc literal should have a return type restriction
         CRYSTAL
     end
   end

--- a/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
+++ b/spec/ameba/rule/typing/proc_literal_return_type_restriction_spec.cr
@@ -6,13 +6,13 @@ module Ameba::Rule::Typing
 
     it "passes if a proc literal has a return type restriction" do
       expect_no_issues subject, <<-CRYSTAL
-        my_proc = ->(var : String) : Nil { puts var }
+        my_proc = -> (var : String) : Nil { puts var }
         CRYSTAL
     end
 
     it "fails if a proc literal doesn't have a return type restriction" do
       expect_issue subject, <<-CRYSTAL
-        my_proc = ->(var : String) { puts var }
+        my_proc = -> (var : String) { puts var }
                 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Proc literal should have a return type restriction
         CRYSTAL
     end

--- a/src/ameba/rule/lint/require_parentheses.cr
+++ b/src/ameba/rule/lint/require_parentheses.cr
@@ -6,14 +6,16 @@ module Ameba::Rule::Lint
   # For example, this is considered invalid:
   #
   # ```
-  # if foo.includes? "bar" || foo.includes? "batz"
+  # if foo.includes? "bar" || foo.includes? "baz"
+  #   # ...
   # end
   # ```
   #
   # And need to be written as:
   #
   # ```
-  # if foo.includes?("bar") || foo.includes?("batz")
+  # if foo.includes?("bar") || foo.includes?("baz")
+  #   # ...
   # end
   # ```
   #


### PR DESCRIPTION
Refactors specs to be more transparent by making them more synthetic, removing redundant code and dividing the test cases into smaller chunks.

/cc @nobodywasishere