### PR TITLE
Add `Lint/WhitespaceAroundMacroExpression` rule

### DIFF
--- a/spec/ameba/rule/lint/whitespace_around_macro_expression_spec.cr
+++ b/spec/ameba/rule/lint/whitespace_around_macro_expression_spec.cr
@@ -1,0 +1,52 @@
+require "../../../spec_helper"
+
+module Ameba::Rule::Lint
+  describe WhitespaceAroundMacroExpression do
+    subject = WhitespaceAroundMacroExpression.new
+
+    it "passes if macro expression is wrapped with whitespace" do
+      expect_no_issues subject, <<-CRYSTAL
+        {{ foo }}
+        CRYSTAL
+    end
+
+    it "reports macro expression without whitespace around" do
+      source = expect_issue subject, <<-CRYSTAL
+        {{foo}}
+        # ^^^^^ error: Missing spaces around macro expression
+        {{ bar}}
+        # ^^^^^^ error: Missing spaces around macro expression
+        {{baz }}
+        # ^^^^^^ error: Missing spaces around macro expression
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        {{ foo }}
+        {{ bar }}
+        {{ baz }}
+        CRYSTAL
+    end
+
+    # https://github.com/crystal-lang/crystal/pull/15524
+    it "reports macro expression without whitespace around within a macro body" do
+      source = expect_issue subject, <<-CRYSTAL
+        {% begin %}
+          {{foo}}
+        # ^^^^^^^ error: Missing spaces around macro expression
+          {{ bar}}
+        # ^^^^^^^^ error: Missing spaces around macro expression
+          {{baz }}
+        # ^^^^^^^^ error: Missing spaces around macro expression
+        {% end %}
+        CRYSTAL
+
+      expect_correction source, <<-CRYSTAL
+        {% begin %}
+          {{ foo }}
+          {{ bar }}
+          {{ baz }}
+        {% end %}
+        CRYSTAL
+    end
+  end
+end

--- a/src/ameba/ast/visitors/node_visitor.cr
+++ b/src/ameba/ast/visitors/node_visitor.cr
@@ -31,6 +31,7 @@ module Ameba::AST
       InstanceVar,
       IsA,
       LibDef,
+      MacroExpression,
       ModuleDef,
       MultiAssign,
       NilLiteral,

--- a/src/ameba/rule/lint/whitespace_around_macro_expression.cr
+++ b/src/ameba/rule/lint/whitespace_around_macro_expression.cr
@@ -1,0 +1,45 @@
+module Ameba::Rule::Lint
+  # A rule that checks for whitespace around macro expressions.
+  #
+  # This is considered invalid:
+  #
+  # ```
+  # {{foo}}
+  # ```
+  #
+  # And it has to written as this instead:
+  #
+  # ```
+  # {{ foo }}
+  # ```
+  #
+  # YAML configuration example:
+  #
+  # ```
+  # Lint/WhitespaceAroundMacroExpression:
+  #   Enabled: true
+  # ```
+  class WhitespaceAroundMacroExpression < Base
+    include AST::Util
+
+    properties do
+      since_version "1.7.0"
+      description "Reports missing spaces around macro expressions"
+    end
+
+    MSG = "Missing spaces around macro expression"
+
+    def test(source, node : Crystal::MacroExpression)
+      return unless node.output?
+      return unless code = node_source(node, source.lines)
+      return if code.starts_with?("{{ ") && code.ends_with?(" }}")
+
+      issue_for node, MSG do |corrector|
+        corrected_code =
+          "{{ #{code.lstrip('{').rstrip('}').strip(' ')} }}"
+
+        corrector.replace(node, corrected_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/crystal-lang/crystal/pull/15524