### PR TITLE
Add `unless` to nodes counted by `AST::CountingVisitor`

### DIFF
--- a/src/ameba/ast/visitors/counting_visitor.cr
+++ b/src/ameba/ast/visitors/counting_visitor.cr
@@ -22,7 +22,7 @@ module Ameba::AST
     # Uses the same logic than rubocop. See
     # https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/metrics/cyclomatic_complexity.rb#L21
     # Except "for", because crystal doesn't have a "for" loop.
-    {% for node in %i[if while until rescue or and] %}
+    {% for node in %i[if unless while until rescue or and] %}
       # :nodoc:
       def visit(node : Crystal::{{ node.id.capitalize }})
         @count += 1 unless macro_condition?

--- a/src/ameba/rule/metrics/cyclomatic_complexity.cr
+++ b/src/ameba/rule/metrics/cyclomatic_complexity.cr
@@ -6,13 +6,13 @@ module Ameba::Rule::Metrics
   # ```
   # Metrics/CyclomaticComplexity:
   #   Enabled: true
-  #   MaxComplexity: 10
+  #   MaxComplexity: 12
   # ```
   class CyclomaticComplexity < Base
     properties do
       since_version "0.9.1"
       description "Disallows methods with a cyclomatic complexity higher than `MaxComplexity`"
-      max_complexity 10
+      max_complexity 12
     end
 
     MSG = "Cyclomatic complexity too high [%d/%d]"

--- a/src/ameba/rule/style/is_a_filter.cr
+++ b/src/ameba/rule/style/is_a_filter.cr
@@ -58,33 +58,25 @@ module Ameba::Rule::Style
 
     def test(source, node : Crystal::Call)
       return unless node.name.in?(filter_names)
-      return unless filter_location = name_location(node)
-      return unless block = node.block
+      return unless location = name_location(node)
+      return unless (block = node.block) && block.args.size == 1
       return unless (body = block.body).is_a?(Crystal::IsA)
       return unless (path = body.const).is_a?(Crystal::Path)
       return unless body.obj.is_a?(Crystal::Var)
-      return if block.args.size > 1
 
       name = path.names.join("::")
       name = "::#{name}" if path.global? && !body.nil_check?
-
-      end_location = node.end_location
-      if !end_location || end_location.try(&.column_number.zero?)
-        if end_location = path.end_location
-          end_location = end_location.adjust(column_number: 1)
-        end
-      end
 
       old = OLD % node.name
       new = NEW % {node.name, name}
       msg = MSG % {new, old}
 
-      if end_location
-        issue_for(filter_location, end_location, msg) do |corrector|
-          corrector.replace(filter_location, end_location, new)
+      if end_location = node.end_location
+        issue_for(location, end_location, msg) do |corrector|
+          corrector.replace(location, end_location, new)
         end
       else
-        issue_for(filter_location, nil, msg)
+        issue_for(location, nil, msg)
       end
     end
   end

--- a/src/ameba/source/rewriter/action.cr
+++ b/src/ameba/source/rewriter/action.cr
@@ -127,7 +127,7 @@ class Ameba::Source::Rewriter
     # In case a child has equal range to *action*, it is returned as `:parent`
     #
     # Reminder: an empty range 1...1 is considered disjoint from 1...10
-    protected def analyze_hierarchy(action) # ameba:disable Metrics/CyclomaticComplexity
+    protected def analyze_hierarchy(action)
       # left_index is the index of the first child that isn't completely to the left of action
       left_index = bsearch_child_index { |child| child.end_pos > action.begin_pos }
       # right_index is the index of the first child that is completely on the right of action


### PR DESCRIPTION
This PR also raises default `MaxComplexity` setting of `Metrics/CyclomaticComplexity` rule to _12_, since otherwise a lot of code is gonna trigger that warning. Aside from this fact, I believe it's more sensible value anyway.