### PR TITLE
Do not report `focus` values which are calls or vars in `Lint/SpecFocus`

### DIFF
--- a/spec/ameba/rule/lint/spec_focus_spec.cr
+++ b/spec/ameba/rule/lint/spec_focus_spec.cr
@@ -60,9 +60,29 @@ module Ameba::Rule::Lint
       subject.catch(s).should_not be_valid
     end
 
+    it "reports if there is a spec item with `focus: !true`" do
+      s = Source.new %(
+        it "it", focus: !true do
+        end
+      ), path: "source_spec.cr"
+
+      subject.catch(s).should_not be_valid
+    end
+
     it "does not report if there is non spec block with :focus" do
       s = Source.new %(
         some_method "foo", focus: true do
+        end
+      ), path: "source_spec.cr"
+
+      subject.catch(s).should be_valid
+    end
+
+    it "does not report if is a parameterized focused spec item" do
+      s = Source.new %(
+        def assert_foo(focus = false)
+          it "foo", focus: focus do
+          end
         end
       ), path: "source_spec.cr"
 

--- a/src/ameba/rule/lint/spec_focus.cr
+++ b/src/ameba/rule/lint/spec_focus.cr
@@ -65,7 +65,9 @@ module Ameba::Rule::Lint
       return unless node.block
 
       arg = node.named_args.try &.find(&.name.== "focus")
-      return unless arg
+      return if arg.nil? ||
+                arg.value.is_a?(Crystal::Call) ||
+                arg.value.is_a?(Crystal::Var)
 
       issue_for arg, MSG
     end


### PR DESCRIPTION
Resolves #605