### PR TITLE
`Lint/UselessAssign`: Skip assigns in call args

### DIFF
--- a/spec/ameba/rule/lint/useless_assign_spec.cr
+++ b/spec/ameba/rule/lint/useless_assign_spec.cr
@@ -402,12 +402,13 @@ module Ameba::Rule::Lint
           CRYSTAL
       end
 
-      pending "doesn't report type declaration as a call argument" do
+      it "doesn't report type declaration as a call argument" do
         expect_no_issues subject, <<-CRYSTAL
-          foo Foo(T), foo : T
-          foo Foo, foo : Nil
-          foo foo : String
-          foo foo : String, bar : Int32?, baz : Bool
+          foo bar : String
+          foo bar : String = ""
+          foo bar : String = baz
+          foo bar = baz
+          foo bar = ""
           CRYSTAL
       end
 

--- a/src/ameba/ast/scope.cr
+++ b/src/ameba/ast/scope.cr
@@ -34,6 +34,8 @@ module Ameba::AST
     # The actual AST node that represents a current scope.
     getter node : Crystal::ASTNode
 
+    getter? in_call_args : Crystal::ASTNode? = nil
+
     delegate location, end_location, to_s,
       to: @node
 
@@ -86,6 +88,7 @@ module Ameba::AST
     # scope.add_type_dec_variable(node)
     # ```
     def add_type_dec_variable(node)
+      return if in_call_args?
       type_dec_variables << TypeDecVariable.new(node)
     end
 
@@ -107,6 +110,7 @@ module Ameba::AST
     # scope.assign_variable(var_name, assign_node)
     # ```
     def assign_variable(name, node)
+      return if in_call_args?
       find_variable(name).try &.assign(node, self)
     end
 
@@ -219,6 +223,16 @@ module Ameba::AST
       node == @node &&
         node.location &&
         node.location == @node.location
+    end
+
+    def in_call_args(node, &)
+      if @in_call_args
+        yield
+      else
+        @in_call_args = node
+        yield
+        @in_call_args = nil
+      end
     end
   end
 end

--- a/src/ameba/ast/visitors/scope_visitor.cr
+++ b/src/ameba/ast/visitors/scope_visitor.cr
@@ -168,12 +168,7 @@ module Ameba::AST
     def visit(node : Crystal::Call)
       scope = @current_scope
 
-      case
-      when (scope.top_level? || scope.type_definition?) && record_macro?(node)
-        return false
-      when scope.type_definition? && accessor_macro?(node)
-        return false
-      when scope.def? && special_node?(node)
+      if scope.def? && special_node?(node)
         scope.arguments.each do |arg|
           ref = arg.variable.reference(scope)
           ref.explicit = false
@@ -196,21 +191,6 @@ module Ameba::AST
 
     private def special_node?(node)
       node.name.in?(SPECIAL_NODE_NAMES) && node.args.empty?
-    end
-
-    private def accessor_macro?(node)
-      node.name.matches? /^(class_)?(getter[?!]?|setter|property[?!]?)$/
-    end
-
-    private def record_macro?(node)
-      return false unless node.name == "record"
-
-      case node.args.first?
-      when Crystal::Path, Crystal::Generic
-        true
-      else
-        false
-      end
     end
 
     private def skip?(node)

--- a/src/ameba/ast/visitors/scope_visitor.cr
+++ b/src/ameba/ast/visitors/scope_visitor.cr
@@ -28,7 +28,7 @@ module Ameba::AST
     @current_visibility : Crystal::Visibility?
     @skip : Array(Crystal::ASTNode.class)?
 
-    def initialize(@rule, @source, skip = nil)
+    def initialize(@rule, @source, skip = nil, @skip_call_args = false)
       @current_scope = Scope.new(@source.ast) # top level scope
       @skip = skip.try &.map(&.as(Crystal::ASTNode.class))
 
@@ -179,6 +179,18 @@ module Ameba::AST
           ref.explicit = false
         end
       end
+
+      if @skip_call_args
+        node.obj.try &.accept self
+        scope.in_call_args(node) do
+          node.args.each &.accept self
+          node.named_args.try &.each &.accept self
+        end
+        node.block_arg.try &.accept self
+        node.block.try &.accept self
+        return false
+      end
+
       true
     end
 

--- a/src/ameba/rule/lint/useless_assign.cr
+++ b/src/ameba/rule/lint/useless_assign.cr
@@ -36,7 +36,7 @@ module Ameba::Rule::Lint
     MSG = "Useless assignment to variable `%s`"
 
     def test(source)
-      AST::ScopeVisitor.new self, source
+      AST::ScopeVisitor.new self, source, skip_call_args: true
     end
 
     def test(source, node, scope : AST::Scope)


### PR DESCRIPTION
Assignments in method call args are very unusual. They should likely be considered a style violation, regardless of whether they are useless or not.
However, assignments in arguments to macro calls are a quite common use case (for example, `record` and `property` macros). Currently, there are some hard coded special case rules to ignore calls to these well-known stdlib macros. But this only trying to paint over the most prominent failures. It does not solve the problem. Calls to custom macros are still affected. Same for the `ExcludeTypeDeclarations` config setting, which serves as a similar crutch to reduce a portion of false positives.

We cannot tell whether a call is to a macro or a method without semantic analysis. So currently, such macro calls trigger false positives.

This change ignores assignments inside call args and removes the special-case code that dealt with some well-known macros.

As a result, it may fail to recognize some actual violations when an assignment in a method call argument is useless.
I believe this is a good deal, though. Useless assigns are not a critical issue.
If we cannot achieve the necessary accuracy, it's better to miss out on some violations than spam users with many non-violations.

Resolves #447