### PR TITLE
Skip dynamic literals comparison in `Lint/LiteralsComparison`

### DIFF
--- a/spec/ameba/ast/util_spec.cr
+++ b/spec/ameba/ast/util_spec.cr
@@ -39,18 +39,28 @@ module Ameba::AST
     describe "#static/dynamic_literal?" do
       [
         Crystal::ArrayLiteral.new,
-        Crystal::ArrayLiteral.new([Crystal::StringLiteral.new("foo")] of Crystal::ASTNode),
+        Crystal::ArrayLiteral.new([
+          Crystal::StringLiteral.new("foo"),
+        ] of Crystal::ASTNode),
         Crystal::BoolLiteral.new(false),
         Crystal::CharLiteral.new('a'),
         Crystal::HashLiteral.new,
         Crystal::NamedTupleLiteral.new,
         Crystal::NilLiteral.new,
         Crystal::NumberLiteral.new(42),
-        Crystal::RegexLiteral.new(Crystal::StringLiteral.new("")),
+        Crystal::RegexLiteral.new(Crystal::StringLiteral.new("foo")),
+        Crystal::RegexLiteral.new(Crystal::StringInterpolation.new([
+          Crystal::StringLiteral.new("foo"),
+        ] of Crystal::ASTNode)),
         Crystal::StringLiteral.new("foo"),
+        Crystal::StringInterpolation.new([
+          Crystal::StringLiteral.new("foo"),
+        ] of Crystal::ASTNode),
         Crystal::SymbolLiteral.new("foo"),
         Crystal::TupleLiteral.new([] of Crystal::ASTNode),
-        Crystal::TupleLiteral.new([Crystal::StringLiteral.new("foo")] of Crystal::ASTNode),
+        Crystal::TupleLiteral.new([
+          Crystal::StringLiteral.new("foo"),
+        ] of Crystal::ASTNode),
         Crystal::RangeLiteral.new(
           Crystal::NumberLiteral.new(0),
           Crystal::NumberLiteral.new(10),
@@ -63,8 +73,21 @@ module Ameba::AST
       end
 
       [
-        Crystal::ArrayLiteral.new([Crystal::Path.new(%w[IO])] of Crystal::ASTNode),
-        Crystal::TupleLiteral.new([Crystal::Path.new(%w[IO])] of Crystal::ASTNode),
+        Crystal::StringInterpolation.new([Crystal::Path.new(%w[Foo])] of Crystal::ASTNode),
+        Crystal::ArrayLiteral.new([Crystal::Path.new(%w[Foo])] of Crystal::ASTNode),
+        Crystal::TupleLiteral.new([Crystal::Path.new(%w[Foo])] of Crystal::ASTNode),
+        Crystal::RegexLiteral.new(Crystal::StringInterpolation.new([
+          Crystal::StringLiteral.new("foo"),
+          Crystal::Path.new(%w[Foo]),
+        ] of Crystal::ASTNode)),
+        Crystal::RangeLiteral.new(
+          Crystal::Path.new(%w[Foo]),
+          Crystal::NumberLiteral.new(10),
+          true),
+        Crystal::RangeLiteral.new(
+          Crystal::NumberLiteral.new(10),
+          Crystal::Path.new(%w[Foo]),
+          true),
       ].each do |literal|
         it "properly identifies dynamic node #{literal}" do
           subject.dynamic_literal?(literal).should be_true

--- a/spec/ameba/rule/lint/literals_comparison_spec.cr
+++ b/spec/ameba/rule/lint/literals_comparison_spec.cr
@@ -5,7 +5,7 @@ module Ameba::Rule::Lint
     subject = LiteralsComparison.new
 
     it "passes for valid cases" do
-      expect_no_issues subject, <<-CRYSTAL
+      expect_no_issues subject, <<-'CRYSTAL'
         "foo" == foo
         "foo" != foo
         "foo" == FOO
@@ -14,6 +14,8 @@ module Ameba::Rule::Lint
         foo != "foo"
 
         {start.year, start.month} == {stop.year, stop.month}
+        /foo/ =~ "foo#{bar}"
+        /foo/ !~ "foo#{bar}"
         ["foo"] === [bar]
         [foo] === ["bar"]
         [foo] === [bar]
@@ -25,6 +27,10 @@ module Ameba::Rule::Lint
     it "reports if there is a static comparison evaluating to the same" do
       expect_issue subject, <<-CRYSTAL
         "foo" === "bar"
+        # ^^^^^^^^^^^^^ error: Comparison always evaluates to the same
+        /foo/ =~ "bar"
+        # ^^^^^^^^^^^^ error: Comparison always evaluates to the same
+        "foo" <=> "bar"
         # ^^^^^^^^^^^^^ error: Comparison always evaluates to the same
         CRYSTAL
     end

--- a/spec/ameba/rule/lint/literals_comparison_spec.cr
+++ b/spec/ameba/rule/lint/literals_comparison_spec.cr
@@ -12,20 +12,13 @@ module Ameba::Rule::Lint
         FOO == "foo"
         foo == "foo"
         foo != "foo"
-        CRYSTAL
-    end
 
-    it "reports if there is a dynamic comparison possibly evaluating to the same" do
-      expect_issue subject, <<-CRYSTAL
-        [foo] === [bar]
-        # ^^^^^^^^^^^^^ error: Comparison most likely evaluates to the same
-        CRYSTAL
-    end
-
-    it "reports if there is a partial dynamic comparison possibly evaluating to the same" do
-      expect_issue subject, <<-CRYSTAL
+        {start.year, start.month} == {stop.year, stop.month}
         ["foo"] === [bar]
-        # ^^^^^^^^^^^^^^^ error: Comparison most likely evaluates to the same
+        [foo] === ["bar"]
+        [foo] === [bar]
+        [foo] == [bar]
+        [foo] == [foo]
         CRYSTAL
     end
 
@@ -36,7 +29,7 @@ module Ameba::Rule::Lint
         CRYSTAL
     end
 
-    it "reports if there is a static comparison evaluating to true (2)" do
+    it "reports if there is a static comparison evaluating to true" do
       expect_issue subject, <<-CRYSTAL
         "foo" == "foo"
         # ^^^^^^^^^^^^ error: Comparison always evaluates to `true`

--- a/spec/ameba/rule/lint/literals_comparison_spec.cr
+++ b/spec/ameba/rule/lint/literals_comparison_spec.cr
@@ -39,12 +39,16 @@ module Ameba::Rule::Lint
       expect_issue subject, <<-CRYSTAL
         "foo" == "foo"
         # ^^^^^^^^^^^^ error: Comparison always evaluates to `true`
+        "foo" != "bar"
+        # ^^^^^^^^^^^^ error: Comparison always evaluates to `true`
         CRYSTAL
     end
 
     it "reports if there is a static comparison evaluating to false" do
       expect_issue subject, <<-CRYSTAL
-        "foo" != "bar"
+        "foo" == "bar"
+        # ^^^^^^^^^^^^ error: Comparison always evaluates to `false`
+        "foo" != "foo"
         # ^^^^^^^^^^^^ error: Comparison always evaluates to `false`
         CRYSTAL
     end

--- a/src/ameba/ast/util.cr
+++ b/src/ameba/ast/util.cr
@@ -12,10 +12,15 @@ module Ameba::AST::Util
          Crystal::CharLiteral,
          Crystal::StringLiteral,
          Crystal::SymbolLiteral,
-         Crystal::RegexLiteral,
          Crystal::ProcLiteral,
          Crystal::MacroLiteral
       {true, true}
+    when Crystal::StringInterpolation
+      {true, node.expressions.all? do |exp|
+        static_literal?(exp)
+      end}
+    when Crystal::RegexLiteral
+      {true, static_literal?(node.value)}
     when Crystal::RangeLiteral
       {true, static_literal?(node.from) &&
         static_literal?(node.to)}

--- a/src/ameba/rule/lint/literals_comparison.cr
+++ b/src/ameba/rule/lint/literals_comparison.cr
@@ -35,12 +35,12 @@ module Ameba::Rule::Lint
       return unless static_literal?(obj)
       return unless static_literal?(arg)
 
-      is_equal = obj.to_s == arg.to_s
-
       what =
         case node.name
-        when "==", "!="
-          "`#{is_equal}`"
+        when "=="
+          "`#{obj.to_s == arg.to_s}`"
+        when "!="
+          "`#{obj.to_s != arg.to_s}`"
         else
           "the same"
         end

--- a/src/ameba/rule/lint/literals_comparison.cr
+++ b/src/ameba/rule/lint/literals_comparison.cr
@@ -26,19 +26,15 @@ module Ameba::Rule::Lint
 
     OP_NAMES = %w[=== == !=]
 
-    MSG        = "Comparison always evaluates to %s"
-    MSG_LIKELY = "Comparison most likely evaluates to %s"
+    MSG = "Comparison always evaluates to %s"
 
     def test(source, node : Crystal::Call)
       return unless node.name.in?(OP_NAMES)
       return unless (obj = node.obj) && (arg = node.args.first?)
 
-      obj_is_literal, obj_is_static = literal_kind?(obj)
-      arg_is_literal, arg_is_static = literal_kind?(arg)
+      return unless static_literal?(obj)
+      return unless static_literal?(arg)
 
-      return unless obj_is_literal && arg_is_literal
-
-      is_dynamic = !obj_is_static || !arg_is_static
       is_equal = obj.to_s == arg.to_s
 
       what =
@@ -49,7 +45,7 @@ module Ameba::Rule::Lint
           "the same"
         end
 
-      issue_for node, (is_dynamic ? MSG_LIKELY : MSG) % what
+      issue_for node, MSG % what
     end
   end
 end

--- a/src/ameba/rule/lint/literals_comparison.cr
+++ b/src/ameba/rule/lint/literals_comparison.cr
@@ -24,7 +24,7 @@ module Ameba::Rule::Lint
       description "Identifies comparisons between literals"
     end
 
-    OP_NAMES = %w[=== == !=]
+    OP_NAMES = %w[=== == != =~ !~ < <= > >= <=>]
 
     MSG = "Comparison always evaluates to %s"
 


### PR DESCRIPTION
Followup to #630 + adds additional operators (`=~ !~ < <= > >= <=>`)