### PR TITLE
Ignore Regex character types in `Style/HeredocEscape`

### DIFF
--- a/spec/ameba/rule/style/heredoc_escape_spec.cr
+++ b/spec/ameba/rule/style/heredoc_escape_spec.cr
@@ -103,6 +103,17 @@ module Ameba::Rule::Style
         CRYSTAL
     end
 
+    it "passes if an escaped heredoc contains Regex escape sequences" do
+      expect_no_issues subject, <<-'CRYSTAL'
+        <<-'REGEX'
+          ^(?:(?<days>\d+)(?:d|\s*days?),?\s*)?
+          (?:(?<hours>\d+)(?:h|\s*hours?),?\s*)?
+          (?:(?<minutes>\d+)(?:m|\s*min(?:utes?)?),?\s*)?
+          (?:(?<seconds>\d+)(?:s|\s*sec(?:onds?)?))?$
+          REGEX
+        CRYSTAL
+    end
+
     it "passes if an escaped heredoc contains escaped escape sequences" do
       expect_no_issues subject, <<-'CRYSTAL'
         <<-'HEREDOC'

--- a/src/ameba/rule/style/heredoc_escape.cr
+++ b/src/ameba/rule/style/heredoc_escape.cr
@@ -38,7 +38,7 @@ module Ameba::Rule::Style
     MSG_ESCAPE_NOT_NEEDED = "Use an unescaped heredoc marker: `<<-%s`"
 
     ESCAPE_SEQUENCE_PATTERN =
-      /\\(?:[abefnrtv]|[0-7]{1,3}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]{1,6}\})/
+      /\\(?:[abefnrtv]|[CdDhHRsSvVwWX]|[0-7]{1,3}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|u\{[0-9a-fA-F]{1,6}\})/
 
     def test(source, node : Crystal::StringInterpolation)
       # Heredocs without interpolations have always size of 1


### PR DESCRIPTION
Fixes #634