### PR TITLE
Constantinize issue messages in `Lint/RedundantWithIndex`

### DIFF
--- a/spec/ameba/rule/lint/redundant_with_index_spec.cr
+++ b/spec/ameba/rule/lint/redundant_with_index_spec.cr
@@ -78,7 +78,7 @@ module Ameba::Rule::Lint
         issue.rule.should_not be_nil
         issue.location.to_s.should eq "source.cr:2:19"
         issue.end_location.to_s.should eq "source.cr:2:28"
-        issue.message.should eq "Remove redundant with_index"
+        issue.message.should eq "Remove redundant `with_index`"
       end
     end
 
@@ -156,7 +156,7 @@ module Ameba::Rule::Lint
         issue.rule.should_not be_nil
         issue.location.to_s.should eq "source.cr:2:14"
         issue.end_location.to_s.should eq "source.cr:2:28"
-        issue.message.should eq "Use each instead of each_with_index"
+        issue.message.should eq "Use `each` instead of `each_with_index`"
       end
     end
   end

--- a/src/ameba/rule/lint/redundant_with_index.cr
+++ b/src/ameba/rule/lint/redundant_with_index.cr
@@ -33,6 +33,9 @@ module Ameba::Rule::Lint
       description "Disallows redundant `with_index` calls"
     end
 
+    MSG_WITH_INDEX      = "Remove redundant `with_index`"
+    MSG_EACH_WITH_INDEX = "Use `each` instead of `each_with_index`"
+
     def test(source, node : Crystal::Call)
       args, block = node.args, node.block
 
@@ -41,9 +44,9 @@ module Ameba::Rule::Lint
 
       case node.name
       when "with_index"
-        report source, node, "Remove redundant with_index"
+        report source, node, MSG_WITH_INDEX
       when "each_with_index"
-        report source, node, "Use each instead of each_with_index"
+        report source, node, MSG_EACH_WITH_INDEX
       end
     end
 


### PR DESCRIPTION
Also wraps the keywords in backticks to highlight them properly.