### PR TITLE
Add `OnlyTwoElementUnions` setting to the `Style/VerboseNilType` rule

### DIFF
--- a/spec/ameba/rule/style/verbose_nil_type_spec.cr
+++ b/spec/ameba/rule/style/verbose_nil_type_spec.cr
@@ -125,6 +125,32 @@ module Ameba::Rule::Style
           bar : String | Nil
           CRYSTAL
       end
+
+      it "#only_two_element_unions" do
+        rule = VerboseNilType.new
+        rule.only_two_element_unions = true
+
+        expect_no_issues rule, <<-CRYSTAL
+          foo : String | Number | Nil
+          bar : String?
+          baz : Nil
+          CRYSTAL
+
+        source = expect_issue rule, <<-CRYSTAL
+          foo : String | Nil = nil
+              # ^^^^^^^^^^^^ error: Prefer `?` instead of `| Nil` in unions
+          bar : String | Nil
+              # ^^^^^^^^^^^^ error: Prefer `?` instead of `| Nil` in unions
+          baz : String | Number?
+              # ^^^^^^^^^^^^^^^^ error: Prefer `| Nil` instead of `?` in unions
+          CRYSTAL
+
+        expect_correction source, <<-CRYSTAL
+          foo : String? = nil
+          bar : String?
+          baz : String | Number | Nil
+          CRYSTAL
+      end
     end
   end
 end

--- a/src/ameba/rule/style/verbose_nil_type.cr
+++ b/src/ameba/rule/style/verbose_nil_type.cr
@@ -15,12 +15,16 @@ module Ameba::Rule::Style
   #
   # Enable the `ExplicitNil` option to enforce the opposite behavior.
   #
+  # The `OnlyTwoElementUnions` option mixes the two approaches, requiring short version (`?`)
+  # in two-element unions and verbose version (`| Nil`) in multi-element unions.
+  #
   # YAML configuration example:
   #
   # ```
   # Style/VerboseNilType:
   #   Enabled: true
   #   ExplicitNil: false
+  #   OnlyTwoElementUnions: false
   # ```
   class VerboseNilType < Base
     include AST::Util
@@ -29,6 +33,7 @@ module Ameba::Rule::Style
       since_version "1.7.0"
       description "Enforces consistent naming of `Nil` in type unions"
       explicit_nil false
+      only_two_element_unions false
     end
 
     MSG_VERBOSE = "Prefer `?` instead of `| Nil` in unions"
@@ -45,7 +50,7 @@ module Ameba::Rule::Style
       return if node_source.includes?(".class")
 
       # `String?` -> `String | Nil`
-      if explicit_nil?
+      if explicit_nil? || (only_two_element_unions? && type_count(node) > 2)
         return unless node_source.ends_with?('?')
 
         issue_for(node, MSG_SHORT) do |corrector|
@@ -82,6 +87,12 @@ module Ameba::Rule::Style
             .gsub(SINGLE_TYPE_PATTERN, "\\1")
         end
         corrector.replace(node, corrected_code)
+      end
+    end
+
+    private def type_count(node : Crystal::Union)
+      node.types.sum do |type|
+        type.is_a?(Crystal::Union) ? type.types.size : 1
       end
     end
 


### PR DESCRIPTION
Resolves #890