### PR TITLE
Revert "Skip CI on automated JSON Schema updates"

### DIFF
--- a/.github/workflows/update-json-schema.yml
+++ b/.github/workflows/update-json-schema.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Commit and push changes
         if: steps.git-diff-changes.outputs.has-changes == 'true'
         run: |
-          git commit -am "Update JSON Schema [skip ci]"
+          git commit -am "Update JSON Schema"
           git push -u origin HEAD


### PR DESCRIPTION
Reverts crystal-ameba/ameba#855

This prevented the CI release workflow from running.